### PR TITLE
chore(skill): remove Co-Authored-By trailer from commit convention

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -166,7 +166,14 @@ Atlas 当前合法 scope（按 `apps/` 和模块边界）：
 
 - `BREAKING CHANGE: <说明>`
 - `Closes #123` / `Refs #123`
-- 必须包含 `Co-Authored-By` 行（Atlas 通过 Claude Code vibe coding，标记归属）
+
+### ❌ 不要加 Co-Authored-By trailer
+
+**Atlas 项目特例**：commit message 里**不**加 `Co-Authored-By: Claude ...` 行。
+
+理由：GitHub 把 trailer 渲染成共同作者并排显示，会让 commit 看起来像 Claude 主导而不是用户主导。归属信息不需要写进 commit 历史。
+
+> 这条覆盖 Claude Code 的默认行为。即使其他指引提示要加，本项目下也**不加**。
 
 ### 示例
 
@@ -178,8 +185,6 @@ POST /chat takes { query, conversationId } and streams agent loop
 output via SSE. Chose SSE over WebSocket because the protocol is
 unidirectional server→client and SSE works in browsers without
 extra deps.
-
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 ```
 
 ❌ 不好：
@@ -196,8 +201,6 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
   feat(daemon): add /chat endpoint
 
   POST /chat ...
-
-  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
   EOF
   )"
   ```


### PR DESCRIPTION
## Summary
Stop adding the `Co-Authored-By: Claude ...` trailer in Atlas commits. The trailer makes Claude appear as a prominent co-author on the GitHub UI and mis-attributes primary contribution away from the project owner.

## Changes
- `.claude/skills/git-workflow/SKILL.md`:
  - Remove the "footer must include Co-Authored-By" rule
  - Add an explicit "❌ 不要加 Co-Authored-By trailer" policy section
  - Strip the trailer from the good-example commit body and the HEREDOC template

## Test plan
- [ ] `grep "Co-Authored-By" .claude/skills/git-workflow/SKILL.md` shows only the new policy section
- [ ] Future commits via this skill produce messages without the trailer (this PR's own commit is the first sample — verify on GitHub UI that the commit shows only the user as author, no Claude co-author chip)

## Related
Closes #1