### PR TITLE
feat(daemon): add provider layer + claude-cli passthrough

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -3,13 +3,15 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun --watch src/index.ts",
-    "start": "bun src/index.ts",
+    "dev": "bun --watch src/server.ts",
+    "start": "bun src/server.ts",
     "test": "bun test",
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "hono": "^4.6.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.2.123",
+    "hono": "^4.6.0",
+    "zod": "^4.4.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/apps/daemon/src/http/chat.test.ts
+++ b/apps/daemon/src/http/chat.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'bun:test';
+import { buildApp } from '../index';
+import type { Provider } from '../providers/types';
+import { ProviderRegistry } from '../providers/registry';
+
+function fakeProvider(): Provider {
+  return {
+    id: 'anthropic-claude-cli',
+    displayName: 'Claude (fake)',
+    authMode: 'cli-passthrough',
+    status: async () => ({ loggedIn: true }),
+    chat: async function* () {
+      yield { type: 'text-delta', text: 'hello ' };
+      yield { type: 'text-delta', text: 'world' };
+      yield { type: 'done' };
+    },
+  };
+}
+
+function appWithFake(): ReturnType<typeof buildApp> {
+  const registry = new ProviderRegistry();
+  registry.register(fakeProvider());
+  return buildApp({ registry });
+}
+
+describe('POST /chat', () => {
+  it('returns 400 when body is invalid', async () => {
+    const app = appWithFake();
+    const res = await app.request('/chat', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when providerId is unknown', async () => {
+    const app = appWithFake();
+    const res = await app.request('/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerId: 'does-not-exist',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('streams SSE events for a known provider', async () => {
+    const app = appWithFake();
+    const res = await app.request('/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerId: 'anthropic-claude-cli',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type') ?? '').toContain('text/event-stream');
+    const body = await res.text();
+    expect(body).toContain('event: text-delta');
+    expect(body).toContain('"text":"hello "');
+    expect(body).toContain('"text":"world"');
+    expect(body).toContain('event: done');
+  });
+});

--- a/apps/daemon/src/http/chat.ts
+++ b/apps/daemon/src/http/chat.ts
@@ -1,0 +1,56 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import type { ProviderRegistry } from '../providers/registry';
+import { sseStream } from './sse';
+
+const chatRequestSchema = z.object({
+  providerId: z.string().min(1),
+  model: z.string().min(1).optional(),
+  messages: z
+    .array(
+      z.object({
+        role: z.enum(['user', 'assistant', 'system']),
+        content: z.string(),
+      }),
+    )
+    .min(1),
+});
+
+export function chatRouter(registry: ProviderRegistry): Hono {
+  const app = new Hono();
+
+  app.post('/', async (c) => {
+    const raw = await c.req.json().catch(() => null);
+    const parsed = chatRequestSchema.safeParse(raw);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid request', issues: parsed.error.issues }, 400);
+    }
+
+    const provider = registry.get(parsed.data.providerId);
+    if (!provider) {
+      return c.json({ error: `unknown providerId: ${parsed.data.providerId}` }, 404);
+    }
+
+    const ac = new AbortController();
+    c.req.raw.signal.addEventListener('abort', () => ac.abort(), { once: true });
+
+    const stream = sseStream(
+      provider.chat({
+        providerId: provider.id,
+        model: parsed.data.model,
+        messages: parsed.data.messages,
+        signal: ac.signal,
+      }),
+    );
+
+    return new Response(stream, {
+      headers: {
+        'content-type': 'text/event-stream; charset=utf-8',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+      },
+    });
+  });
+
+  return app;
+}

--- a/apps/daemon/src/http/providers.test.ts
+++ b/apps/daemon/src/http/providers.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'bun:test';
+import { buildApp } from '../index';
+import type { Provider } from '../providers/types';
+import { ProviderRegistry } from '../providers/registry';
+
+function fakeProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    id: 'anthropic-claude-cli',
+    displayName: 'Claude (fake)',
+    authMode: 'cli-passthrough',
+    status: async () => ({ loggedIn: true, detail: 'subscription: pro' }),
+    chat: async function* () {
+      yield { type: 'done' };
+    },
+    ...overrides,
+  };
+}
+
+function appWith(p: Provider): ReturnType<typeof buildApp> {
+  const registry = new ProviderRegistry();
+  registry.register(p);
+  return buildApp({ registry });
+}
+
+describe('GET /providers', () => {
+  it('lists registered providers with metadata and status', async () => {
+    const app = appWith(fakeProvider());
+    const res = await app.request('/providers');
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Array<{
+      id: string;
+      displayName: string;
+      authMode: string;
+      status: { loggedIn: boolean; detail?: string };
+    }>;
+    expect(json).toHaveLength(1);
+    expect(json[0]?.id).toBe('anthropic-claude-cli');
+    expect(json[0]?.authMode).toBe('cli-passthrough');
+    expect(json[0]?.status.loggedIn).toBe(true);
+    expect(json[0]?.status.detail).toBe('subscription: pro');
+  });
+});
+
+describe('GET /providers/:id/status', () => {
+  it('returns 200 + status for a known provider', async () => {
+    const app = appWith(
+      fakeProvider({
+        status: async () => ({ loggedIn: false, detail: 'not logged in' }),
+      }),
+    );
+    const res = await app.request('/providers/anthropic-claude-cli/status');
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { loggedIn: boolean; detail?: string };
+    expect(json.loggedIn).toBe(false);
+    expect(json.detail).toBe('not logged in');
+  });
+
+  it('returns 404 for an unknown provider', async () => {
+    const app = appWith(fakeProvider());
+    const res = await app.request('/providers/nope/status');
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/daemon/src/http/providers.ts
+++ b/apps/daemon/src/http/providers.ts
@@ -1,0 +1,28 @@
+import { Hono } from 'hono';
+import type { ProviderRegistry } from '../providers/registry';
+
+export function providersRouter(registry: ProviderRegistry): Hono {
+  const app = new Hono();
+
+  app.get('/', async (c) => {
+    const providers = await Promise.all(
+      registry.list().map(async (p) => ({
+        id: p.id,
+        displayName: p.displayName,
+        authMode: p.authMode,
+        status: await p.status(),
+      })),
+    );
+    return c.json(providers);
+  });
+
+  app.get('/:id/status', async (c) => {
+    const provider = registry.get(c.req.param('id'));
+    if (!provider) {
+      return c.json({ error: 'unknown provider' }, 404);
+    }
+    return c.json(await provider.status());
+  });
+
+  return app;
+}

--- a/apps/daemon/src/http/sse.ts
+++ b/apps/daemon/src/http/sse.ts
@@ -1,0 +1,27 @@
+import type { AgentEvent } from '../providers/types';
+
+export function encodeSse(event: AgentEvent): string {
+  const { type, ...rest } = event;
+  return `event: ${type}\ndata: ${JSON.stringify(rest)}\n\n`;
+}
+
+export function sseStream(events: AsyncIterable<AgentEvent>): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        for await (const event of events) {
+          controller.enqueue(encoder.encode(encodeSse(event)));
+        }
+      } catch (err) {
+        controller.enqueue(
+          encoder.encode(
+            encodeSse({ type: 'error', message: (err as Error).message }),
+          ),
+        );
+      } finally {
+        controller.close();
+      }
+    },
+  });
+}

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -1,14 +1,27 @@
 import { Hono } from 'hono';
+import { ProviderRegistry } from './providers/registry';
+import { claudeCliProvider } from './providers/adapters/claude-cli';
+import { providersRouter } from './http/providers';
+import { chatRouter } from './http/chat';
 
-const app = new Hono();
-
-app.get('/health', (c) => c.json({ status: 'ok' }));
-
-const port = Number(process.env.PORT ?? 3001);
-
-console.log(`atlas daemon listening on :${port}`);
-
-export default {
-  port,
-  fetch: app.fetch,
+export type BuildAppOptions = {
+  registry?: ProviderRegistry;
 };
+
+export function buildApp(opts: BuildAppOptions = {}): Hono {
+  const registry = opts.registry ?? createDefaultRegistry();
+
+  const app = new Hono();
+  app.get('/health', (c) => c.json({ status: 'ok' }));
+  app.route('/providers', providersRouter(registry));
+  app.route('/chat', chatRouter(registry));
+  return app;
+}
+
+export function createDefaultRegistry(): ProviderRegistry {
+  const r = new ProviderRegistry();
+  r.register(claudeCliProvider());
+  return r;
+}
+
+export const app = buildApp();

--- a/apps/daemon/src/providers/adapters/claude-cli.test.ts
+++ b/apps/daemon/src/providers/adapters/claude-cli.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'bun:test';
+import { parseAuthStatus } from './claude-cli';
+
+describe('parseAuthStatus', () => {
+  it('parses modern JSON output with max subscription', () => {
+    const stdout = JSON.stringify({
+      loggedIn: true,
+      authMethod: 'claude.ai',
+      apiProvider: 'firstParty',
+      email: 'user@example.com',
+      subscriptionType: 'max',
+    });
+    const result = parseAuthStatus(stdout);
+    expect(result.loggedIn).toBe(true);
+    expect(result.detail).toContain('max');
+    expect(result.detail).toContain('user@example.com');
+  });
+
+  it('parses modern JSON output when not logged in', () => {
+    const stdout = JSON.stringify({ loggedIn: false });
+    const result = parseAuthStatus(stdout);
+    expect(result.loggedIn).toBe(false);
+  });
+
+  it('parses legacy text output with subscription', () => {
+    const stdout = 'Logged in as foo@bar.com (subscription: pro)\n';
+    const result = parseAuthStatus(stdout);
+    expect(result.loggedIn).toBe(true);
+    expect(result.detail).toBe('subscription: pro');
+  });
+
+  it('returns loggedIn=false on garbage output', () => {
+    const result = parseAuthStatus('???');
+    expect(result.loggedIn).toBe(false);
+  });
+});

--- a/apps/daemon/src/providers/adapters/claude-cli.ts
+++ b/apps/daemon/src/providers/adapters/claude-cli.ts
@@ -1,0 +1,181 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import type {
+  AgentEvent,
+  ChatRequest,
+  Provider,
+  ProviderStatus,
+} from '../types';
+
+const execFileAsync = promisify(execFile);
+
+function buildSubscriptionEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.ANTHROPIC_API_KEY;
+  delete env.ANTHROPIC_AUTH_TOKEN;
+  return env;
+}
+
+function messagesToPrompt(messages: ChatRequest['messages']): string {
+  // Claude SDK 接受单个 prompt string 或 AsyncIterable<SDKUserMessage>。
+  // 早期阶段我们只支持单轮：取最后一条 user 消息直接交给 SDK。
+  // 多轮历史要走 SDK 的 resume/session 机制，留给后续 issue。
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m && m.role === 'user') return m.content;
+  }
+  throw new Error('chat request must contain at least one user message');
+}
+
+type AuthStatusJson = {
+  loggedIn?: boolean;
+  subscriptionType?: string;
+  email?: string;
+};
+
+export function parseAuthStatus(stdout: string): ProviderStatus {
+  const trimmed = stdout.trim();
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed) as AuthStatusJson;
+      if (typeof parsed.loggedIn === 'boolean') {
+        const parts: string[] = [];
+        if (parsed.subscriptionType) {
+          parts.push(`subscription: ${parsed.subscriptionType}`);
+        }
+        if (parsed.email) parts.push(parsed.email);
+        const detail = parts.join(' · ');
+        return { loggedIn: parsed.loggedIn, ...(detail && { detail }) };
+      }
+    } catch {
+      // Not valid JSON; fall through to legacy text parsing.
+    }
+  }
+
+  const loggedIn = /logged in/i.test(trimmed);
+  const subscription = /subscription:\s*(\w+)/i.exec(trimmed)?.[1];
+  return {
+    loggedIn,
+    ...(subscription
+      ? { detail: `subscription: ${subscription}` }
+      : trimmed
+        ? { detail: trimmed }
+        : {}),
+  };
+}
+
+async function detectStatus(): Promise<ProviderStatus> {
+  try {
+    const { stdout } = await execFileAsync('claude', ['auth', 'status'], {
+      timeout: 10_000,
+      env: { ...process.env, ANTHROPIC_API_KEY: '' },
+    });
+    return parseAuthStatus(stdout);
+  } catch (err) {
+    return { loggedIn: false, detail: (err as Error).message };
+  }
+}
+
+async function* runChat(req: ChatRequest): AsyncIterable<AgentEvent> {
+  const prompt = messagesToPrompt(req.messages);
+  const ac = new AbortController();
+  if (req.signal) {
+    if (req.signal.aborted) ac.abort();
+    else
+      req.signal.addEventListener('abort', () => ac.abort(), { once: true });
+  }
+
+  const handle = query({
+    prompt,
+    options: {
+      model: req.model,
+      permissionMode: 'bypassPermissions',
+      cwd: process.cwd(),
+      env: buildSubscriptionEnv(),
+      includePartialMessages: true,
+      abortController: ac,
+    },
+  });
+
+  let sessionId: string | undefined;
+  const billing: 'subscription' | 'api' = process.env.ANTHROPIC_API_KEY
+    ? 'api'
+    : 'subscription';
+
+  try {
+    for await (const msg of handle) {
+      const m = msg as Record<string, unknown> & { type: string };
+      if (m.type === 'system' && (m as { subtype?: string }).subtype === 'init') {
+        sessionId = (m as { session_id?: string }).session_id;
+        continue;
+      }
+      if (m.type === 'assistant') {
+        const content =
+          (m as { message?: { content?: Array<Record<string, unknown>> } }).message
+            ?.content ?? [];
+        for (const block of content) {
+          if (block.type === 'text' && typeof block.text === 'string') {
+            yield { type: 'text-delta', text: block.text };
+          } else if (block.type === 'tool_use') {
+            yield {
+              type: 'tool-call',
+              id: String(block.id ?? ''),
+              name: String(block.name ?? ''),
+              args: block.input,
+            };
+          }
+        }
+        continue;
+      }
+      if (m.type === 'user') {
+        const content =
+          (m as { message?: { content?: Array<Record<string, unknown>> } }).message
+            ?.content ?? [];
+        for (const block of content) {
+          if (block.type === 'tool_result') {
+            yield {
+              type: 'tool-result',
+              id: String(block.tool_use_id ?? ''),
+              ok: !block.is_error,
+              result: block.content,
+            };
+          }
+        }
+        continue;
+      }
+      if (m.type === 'result') {
+        const usage = (m as { usage?: Record<string, number> }).usage;
+        const costUsd = (m as { total_cost_usd?: number }).total_cost_usd;
+        yield {
+          type: 'done',
+          sessionId,
+          billing,
+          ...(usage && {
+            usage: {
+              inputTokens: usage.input_tokens ?? 0,
+              outputTokens: usage.output_tokens ?? 0,
+            },
+          }),
+          ...(typeof costUsd === 'number' && { costUsd }),
+        };
+        return;
+      }
+    }
+    yield { type: 'done', sessionId, billing };
+  } catch (err) {
+    yield { type: 'error', message: (err as Error).message };
+  } finally {
+    handle.close?.();
+  }
+}
+
+export function claudeCliProvider(): Provider {
+  return {
+    id: 'anthropic-claude-cli',
+    displayName: 'Claude (subscription via local CLI)',
+    authMode: 'cli-passthrough',
+    status: detectStatus,
+    chat: runChat,
+  };
+}

--- a/apps/daemon/src/providers/credentials.test.ts
+++ b/apps/daemon/src/providers/credentials.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, statSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CredentialStore } from './credentials';
+
+let dir: string;
+let file: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'atlas-cred-'));
+  file = join(dir, 'credentials.json');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('CredentialStore', () => {
+  it('returns undefined when no credential is stored', async () => {
+    const store = new CredentialStore(file);
+    expect(await store.get('openai')).toBeUndefined();
+  });
+
+  it('round-trips a credential', async () => {
+    const store = new CredentialStore(file);
+    await store.set('openai', { apiKey: 'sk-test' });
+    const got = await store.get('openai');
+    expect(got).toEqual({ apiKey: 'sk-test' });
+  });
+
+  it('persists between instances', async () => {
+    await new CredentialStore(file).set('openai', { apiKey: 'sk-test' });
+    const got = await new CredentialStore(file).get('openai');
+    expect(got).toEqual({ apiKey: 'sk-test' });
+  });
+
+  it('writes the credentials file with mode 0600', async () => {
+    const store = new CredentialStore(file);
+    await store.set('openai', { apiKey: 'sk-test' });
+    expect(existsSync(file)).toBe(true);
+    const mode = statSync(file).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('removes a credential', async () => {
+    const store = new CredentialStore(file);
+    await store.set('openai', { apiKey: 'sk-test' });
+    await store.delete('openai');
+    expect(await store.get('openai')).toBeUndefined();
+  });
+});

--- a/apps/daemon/src/providers/credentials.ts
+++ b/apps/daemon/src/providers/credentials.ts
@@ -1,0 +1,56 @@
+import { mkdir, readFile, writeFile, chmod, unlink } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { homedir } from 'node:os';
+
+export type Credential = Record<string, unknown>;
+
+export const defaultCredentialsPath = (): string =>
+  `${homedir()}/.atlas/credentials.json`;
+
+export class CredentialStore {
+  constructor(private readonly path: string = defaultCredentialsPath()) {}
+
+  private async readAll(): Promise<Record<string, Credential>> {
+    try {
+      const raw = await readFile(this.path, 'utf8');
+      return JSON.parse(raw) as Record<string, Credential>;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+      throw err;
+    }
+  }
+
+  private async writeAll(all: Record<string, Credential>): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true });
+    await writeFile(this.path, JSON.stringify(all, null, 2), {
+      mode: 0o600,
+    });
+    await chmod(this.path, 0o600);
+  }
+
+  async get(providerId: string): Promise<Credential | undefined> {
+    const all = await this.readAll();
+    return all[providerId];
+  }
+
+  async set(providerId: string, credential: Credential): Promise<void> {
+    const all = await this.readAll();
+    all[providerId] = credential;
+    await this.writeAll(all);
+  }
+
+  async delete(providerId: string): Promise<void> {
+    const all = await this.readAll();
+    if (!(providerId in all)) return;
+    delete all[providerId];
+    if (Object.keys(all).length === 0) {
+      try {
+        await unlink(this.path);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+      return;
+    }
+    await this.writeAll(all);
+  }
+}

--- a/apps/daemon/src/providers/registry.ts
+++ b/apps/daemon/src/providers/registry.ts
@@ -1,0 +1,17 @@
+import type { Provider, ProviderId } from './types';
+
+export class ProviderRegistry {
+  private readonly providers = new Map<ProviderId, Provider>();
+
+  register(provider: Provider): void {
+    this.providers.set(provider.id, provider);
+  }
+
+  get(id: string): Provider | undefined {
+    return this.providers.get(id as ProviderId);
+  }
+
+  list(): Provider[] {
+    return [...this.providers.values()];
+  }
+}

--- a/apps/daemon/src/providers/types.ts
+++ b/apps/daemon/src/providers/types.ts
@@ -1,0 +1,47 @@
+export type ProviderId = 'anthropic-claude-cli';
+
+export type ChatMessage = {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};
+
+export type ChatRequest = {
+  providerId: ProviderId;
+  model?: string;
+  messages: ChatMessage[];
+  signal?: AbortSignal;
+};
+
+export type AgentEvent =
+  | { type: 'text-delta'; text: string }
+  | { type: 'tool-call'; id: string; name: string; args: unknown }
+  | {
+      type: 'tool-result';
+      id: string;
+      ok: boolean;
+      result?: unknown;
+      error?: string;
+    }
+  | {
+      type: 'done';
+      sessionId?: string;
+      usage?: { inputTokens: number; outputTokens: number };
+      costUsd?: number;
+      billing?: 'subscription' | 'api';
+    }
+  | { type: 'error'; message: string };
+
+export type ProviderStatus = {
+  loggedIn: boolean;
+  detail?: string;
+};
+
+export type AuthMode = 'cli-passthrough' | 'apiKey' | 'oauth';
+
+export type Provider = {
+  id: ProviderId;
+  displayName: string;
+  authMode: AuthMode;
+  status(): Promise<ProviderStatus>;
+  chat(req: ChatRequest): AsyncIterable<AgentEvent>;
+};

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1,0 +1,9 @@
+import { app } from './index';
+
+const port = Number(process.env.PORT ?? 3001);
+console.log(`atlas daemon listening on :${port}`);
+
+export default {
+  port,
+  fetch: app.fetch,
+};

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,9 @@
     "apps/daemon": {
       "name": "@atlas/daemon",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.123",
         "hono": "^4.6.0",
+        "zod": "^4.4.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -21,7 +23,33 @@
     },
   },
   "packages": {
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.123", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.123", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.123", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.123", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.123" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-a4TysYoR9DBdkM9Uwh4J5ub7TwKmRPe5hFiWh4En+IKC+qkk5UFkxFM22c//cZjYZKynHX0ah2t6LUqb+najYA=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.123", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tYAXCjlXZQklsUs0J//gip3fZQRzhlH5OCgvNXV70qe7A1iiwHqO2KPGvEHV1L+deEKQoMZmTaCOrQpN6zju3w=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.123", "", { "os": "darwin", "cpu": "x64" }, "sha512-AcUC6sTon6z6HculP87KsAOeTMRLBwpovdhcXUTjXUpo/8nplJ7lBEzWjZCHt8FF1KuN/WBy1Z4bDg/59TQDmA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.123", "", { "os": "linux", "cpu": "arm64" }, "sha512-7+GnbcF3/aZ8RJ1WmU/ogtPsOpknBAoUPer90MvZuFYBLPT9iI/U7f24gjrOHuYdcbDA5n7jFlhcfIO26F5DJQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.123", "", { "os": "linux", "cpu": "arm64" }, "sha512-bYgRiaf2q+yVbGAoUluuhqrEW1zexL34+3HDmK9DneKXa2K2EJpw4M6Sq4XoBD/JezGaemoAP78Xv/M/QUS1OQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.123", "", { "os": "linux", "cpu": "x64" }, "sha512-Xi+Rwk8uP5vWEnawJOlsk179fr0ATLl5J90MlbLj+puKaX5svEq8ljS+P3zq6zHTJeKh9GKLzPf7bc5YJKwcew=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.123", "", { "os": "linux", "cpu": "x64" }, "sha512-IX95lFKhmmndY/YPfWPsVV+C3rLYJmuuq5wCS53p6jYIkCMxH1iGfhBGF1EUWcXO4Uc8yqXFmQ3aaxMzOOPrwA=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.123", "", { "os": "win32", "cpu": "arm64" }, "sha512-WDZmAQG1rOiqNLZlSXaCjSWmqJvLk2io+vFQWWqSy2b5HCk9pa3PadLiaLztiihyk81wPhH9Q/44kOxdyfEGMw=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.123", "", { "os": "win32", "cpu": "x64" }, "sha512-588xrd1i6d4kXQ6FqwL+cgBiN4evRQSi5DCtPa02CZ3VEbuVQBeFlyPlD8tfWtNNeGZ4NM8kjPNNzZz5omezPA=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
+
     "@atlas/daemon": ["@atlas/daemon@workspace:apps/daemon"],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "https://registry.npmmirror.com/@turbo/darwin-64/-/darwin-64-2.9.6.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
 
@@ -39,14 +67,194 @@
 
     "@types/node": ["@types/node@25.6.0", "https://registry.npmmirror.com/@types/node/-/node-25.6.0.tgz", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "bun-types": ["bun-types@1.3.13", "https://registry.npmmirror.com/bun-types/-/bun-types-1.3.13.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.4.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "hono": ["hono@4.12.15", "https://registry.npmmirror.com/hono/-/hono-4.12.15.tgz", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
 
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "turbo": ["turbo@2.9.6", "https://registry.npmmirror.com/turbo/-/turbo-2.9.6.tgz", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.19.2", "https://registry.npmmirror.com/undici-types/-/undici-types-7.19.2.tgz", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
   }
 }

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -82,13 +82,25 @@ flowchart TB
 
 ## 模块边界
 
-| 模块 | 职责 | 关键依赖（候选） |
-|------|------|------------------|
-| HTTP API Layer | 对外接口、鉴权、SSE 流式输出 | Hono / Fastify |
-| Agent Loop | 推理循环、工具调度、终止条件、状态管理 | Vercel AI SDK |
+| 模块 | 职责 | 关键依赖 |
+|------|------|----------|
+| HTTP API Layer | 对外接口、SSE 流式输出 | Hono |
+| Provider 层 | LLM provider 抽象 + 凭据存储 + 各家 adapter（按 providerId 路由 chat 请求） | `@anthropic-ai/claude-agent-sdk` / Vercel AI SDK |
+| Agent Loop（Native） | 给非 Anthropic provider 跑的推理循环 / 工具调度 / 终止判定 | Vercel AI SDK |
 | Tool Registry | 工具注册、参数 schema 校验、并发执行、超时与重试 | Zod |
-| RAG / Retrieve | 查询改写、向量检索、rerank、上下文拼装 | 向量库 client |
+| RAG / Retrieve | 查询改写、向量检索、rerank、上下文拼装 | 向量库 client（待定） |
 | Ingest Pipeline | 文档解析、切分、embedding、写入向量库 | 解析库（按文档类型） |
+
+## 双轨 Agent 执行
+
+按 `providerId` 路由到两条执行路径，对外暴露**同一种 SSE 事件流**（`text-delta` / `tool-call` / `tool-result` / `done` / `error`）：
+
+| 路径 | 适用 provider | 实现 |
+|------|--------------|------|
+| **Native loop** | OpenAI / Qwen / GLM / Kimi / DeepSeek / Ollama | Atlas 自己跑 ReAct 循环，调 Vercel AI SDK 的 `streamText({ tools, maxSteps })` |
+| **Claude SDK passthrough** | `anthropic-claude-cli`（订阅模式） | 整轮 agent loop 委托给 `@anthropic-ai/claude-agent-sdk` 的 `query()`；spawn 时 env 必须**剥掉** `ANTHROPIC_API_KEY` 才能走订阅而非 API 计费 |
+
+不写统一的 loop 抽象去包两条路径——SDK 不暴露裸调 LLM 接口，强抽象只会做出个错位的中间层。
 
 ## 关键决策
 
@@ -104,16 +116,20 @@ flowchart TB
 | 复杂文档解析 | **允许独立工具/脚本** | Ingest 路径冷、可批处理；语言边界不影响主进程；Python/外部 CLI 都可用 |
 | Web 框架 | **Next.js** | 用户已确认 |
 | 桌面 | Electron（**当前阶段暂缓**） | 仅作为壳；与 daemon 通过 HTTP 通信；先把后端跑通再做 |
+| Agent Loop（native） | **Vercel AI SDK** | provider 抽象 + 流式 + tool calling + maxSteps 一站式；多家 LLM 不需要自己写 SSE 解析 |
+| Anthropic 订阅接入 | **Claude SDK passthrough** | 订阅 OAuth 凭据躺在本机 `claude` CLI 里，没有"裸调 LLM"接口可走；只能 spawn SDK 让它跑整轮 loop |
+| Provider 凭据存储 | **`~/.atlas/credentials.json` + 0600** | 早期单机单用户；不上 keychain（YAGNI），后续多端共享时再换 |
 | 向量库 | 待定 | 实现 RAG 时再决（候选：LanceDB / Qdrant / pgvector） |
 
 ## 数据流：一次问答
 
-1. 客户端 `POST /chat` 携带 query + conversation id
-2. Agent Loop 启动，初始消息进入推理
-3. LLM 决定调用 `retrieve` 工具 → RAG 模块查询向量库（必要时 rerank）
-4. 检索结果作为 tool result 回灌到对话
-5. （可选）LLM 调用 `web_search` 补充信息
-6. LLM 输出最终答复，通过 SSE 流式回客户端
+1. 客户端 `POST /chat` 携带 `providerId` + `messages`（+ 可选 `model`）
+2. Provider 层按 `providerId` 路由：要么走 native loop，要么委托给 Claude SDK passthrough
+3. Agent Loop 启动，初始消息进入推理
+4. LLM 决定调用 `retrieve` 工具 → RAG 模块查询向量库（必要时 rerank）
+5. 检索结果作为 tool result 回灌到对话
+6. （可选）LLM 调用 `web_search` 补充信息
+7. LLM 输出最终答复，通过 SSE 流式回客户端
 
 ## 数据流：文档摄入
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -24,7 +24,14 @@ atlas/
 │       ├── package.json
 │       ├── tsconfig.json
 │       └── src/
-│           └── index.ts        # Hono app entry，目前只有 /health
+│           ├── index.ts        # buildApp + createDefaultRegistry（不带 IO 副作用）
+│           ├── server.ts       # Bun.serve 启动入口
+│           ├── http/           # HTTP 路由：/chat、/providers、SSE 编码
+│           └── providers/      # provider 抽象 + 凭据存储 + 各家 adapter
+│               ├── types.ts
+│               ├── registry.ts
+│               ├── credentials.ts
+│               └── adapters/   # 每家 provider 一个文件，例 claude-cli.ts
 └── docs/                       # 项目文档
     ├── CLAUDE.md               # docs/ 职责说明（工作目录在 docs/ 下时自动加载）
     ├── architecture/


### PR DESCRIPTION
## Summary

为 daemon 立起 provider 抽象层，并接入第一条执行路径 —— **Anthropic Claude SDK passthrough**：复用本机 \`claude\` CLI 的 OAuth 订阅凭据，让用户用自己的 Pro/Max 订阅跑 agent，而不是按 token 走 API 计费。

第二条执行路径（native agent loop + OpenAI / 其他 OpenAI 兼容 provider）由 #4 接力。

## Changes

### Provider 抽象（\`apps/daemon/src/providers/\`）
- \`types.ts\`：统一的 \`Provider\` / \`ChatRequest\` / \`AgentEvent\` 类型
- \`registry.ts\`：进程内 ProviderRegistry，支持注入便于测试
- \`credentials.ts\`：\`~/.atlas/credentials.json\` + 0600（YAGNI 不上 keychain）
- \`adapters/claude-cli.ts\`：Claude SDK passthrough；spawn 时**剥掉** \`ANTHROPIC_API_KEY\` / \`ANTHROPIC_AUTH_TOKEN\` 才能走订阅；\`status()\` 解析 \`claude auth status\` 的 JSON / 文本两种格式

### HTTP（\`apps/daemon/src/http/\`）
- \`GET /providers\`：列出已注册 provider + 各自登录态
- \`GET /providers/:id/status\`：单独探测某个 provider
- \`POST /chat\`：按 \`providerId\` 路由；当前仅 \`anthropic-claude-cli\`
- \`sse.ts\`：把 \`AsyncIterable<AgentEvent>\` 编码成 SSE 流

### Bootstrap 拆分
- \`index.ts\` 变纯：只导出 \`buildApp\` / \`app\`，零 IO 副作用
- \`server.ts\` 接管 Bun.serve 启动 + 端口日志
- 这样测试导入 \`buildApp\` 不会污染 stdout，也方便后续注入 fake registry

### 文档
- \`docs/architecture/overview.md\`：双轨 agent 执行表 + 关键决策（Vercel AI SDK / Claude SDK passthrough / 凭据存储）
- \`docs/project-structure.md\`：新增的 \`http/\` \`providers/\` 目录

## Test plan

- [ ] \`bun --cwd apps/daemon test\` 全绿（15 个用例）
- [ ] \`bun --cwd apps/daemon run check\` 类型干净
- [ ] \`bun --cwd apps/daemon dev\` 启动后：
  - [ ] \`curl localhost:3001/health\` → \`{\"status\":\"ok\"}\`
  - [ ] \`curl localhost:3001/providers\` 列出 \`anthropic-claude-cli\`，\`status.loggedIn\` 反映本机真实状态
  - [ ] 本机已 \`claude /login\` 后：\`curl -N -X POST localhost:3001/chat -H 'content-type: application/json' -d '{\"providerId\":\"anthropic-claude-cli\",\"messages\":[{\"role\":\"user\",\"content\":\"reply with the word: hello\"}]}'\` 看到 \`event: text-delta\` + \`event: done\`，\`done\` 里 \`billing: subscription\`

## Related

Closes #3