### PR TITLE
feat(daemon): add native agent loop + OpenAI API key provider

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -9,11 +9,14 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.54",
     "@anthropic-ai/claude-agent-sdk": "^0.2.123",
+    "ai": "^6.0.170",
     "hono": "^4.6.0",
     "zod": "^4.4.1"
   },
   "devDependencies": {
+    "@ai-sdk/provider": "^3.0.9",
     "@types/bun": "latest",
     "typescript": "^5.7.0"
   }

--- a/apps/daemon/src/agent/loop.test.ts
+++ b/apps/daemon/src/agent/loop.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'bun:test';
+import { MockLanguageModelV3, simulateReadableStream } from 'ai/test';
+import type { LanguageModelV3StreamPart } from '@ai-sdk/provider';
+import { runNativeLoop } from './loop';
+import type { AgentEvent } from '../providers/types';
+
+async function collect(stream: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const event of stream) out.push(event);
+  return out;
+}
+
+describe('runNativeLoop', () => {
+  it('maps a successful stream to text-delta events and a done event', async () => {
+    const chunks: LanguageModelV3StreamPart[] = [
+      { type: 'text-start', id: '1' },
+      { type: 'text-delta', id: '1', delta: 'hello ' },
+      { type: 'text-delta', id: '1', delta: 'world' },
+      { type: 'text-end', id: '1' },
+      {
+        type: 'finish',
+        usage: {
+          inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 2, text: 2, reasoning: 0 },
+        },
+        finishReason: { unified: 'stop', raw: 'stop' },
+      },
+    ];
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({
+        stream: simulateReadableStream({ chunks }),
+      }),
+    });
+
+    const events = await collect(
+      runNativeLoop({
+        model,
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    );
+
+    const deltas = events.filter((e) => e.type === 'text-delta');
+    expect(deltas).toEqual([
+      { type: 'text-delta', text: 'hello ' },
+      { type: 'text-delta', text: 'world' },
+    ]);
+
+    const done = events.find((e) => e.type === 'done');
+    expect(done).toBeDefined();
+    expect(done?.type).toBe('done');
+    if (done?.type === 'done') {
+      expect(done.usage?.inputTokens).toBe(1);
+      expect(done.usage?.outputTokens).toBe(2);
+      expect(done.billing).toBe('api');
+    }
+  });
+
+  it('emits an error event when the model fails', async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    const events = await collect(
+      runNativeLoop({
+        model,
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    );
+
+    const error = events.find((e) => e.type === 'error');
+    expect(error?.type).toBe('error');
+    if (error?.type === 'error') expect(error.message).toContain('boom');
+  });
+});

--- a/apps/daemon/src/agent/loop.ts
+++ b/apps/daemon/src/agent/loop.ts
@@ -1,0 +1,85 @@
+import { streamText, type LanguageModel, type ModelMessage } from 'ai';
+import type { AgentEvent, ChatMessage } from '../providers/types';
+
+export type NativeLoopRequest = {
+  model: LanguageModel;
+  messages: ChatMessage[];
+  signal?: AbortSignal;
+};
+
+function toModelMessages(messages: ChatMessage[]): ModelMessage[] {
+  return messages.map((m) => ({ role: m.role, content: m.content }));
+}
+
+export async function* runNativeLoop(
+  req: NativeLoopRequest,
+): AsyncIterable<AgentEvent> {
+  const result = streamText({
+    model: req.model,
+    messages: toModelMessages(req.messages),
+    abortSignal: req.signal,
+  });
+
+  try {
+    for await (const part of result.fullStream) {
+      switch (part.type) {
+        case 'text-delta':
+          if (part.text) yield { type: 'text-delta', text: part.text };
+          break;
+        case 'tool-call':
+          yield {
+            type: 'tool-call',
+            id: part.toolCallId,
+            name: part.toolName,
+            args: part.input,
+          };
+          break;
+        case 'tool-result':
+          yield {
+            type: 'tool-result',
+            id: part.toolCallId,
+            ok: true,
+            result: part.output,
+          };
+          break;
+        case 'tool-error':
+          yield {
+            type: 'tool-result',
+            id: part.toolCallId,
+            ok: false,
+            error: String(part.error),
+          };
+          break;
+        case 'error':
+          yield {
+            type: 'error',
+            message:
+              part.error instanceof Error
+                ? part.error.message
+                : String(part.error),
+          };
+          return;
+        case 'abort':
+          yield { type: 'error', message: part.reason ?? 'aborted' };
+          return;
+        case 'finish': {
+          const usage = part.totalUsage;
+          yield {
+            type: 'done',
+            billing: 'api',
+            ...(usage && {
+              usage: {
+                inputTokens: usage.inputTokens ?? 0,
+                outputTokens: usage.outputTokens ?? 0,
+              },
+            }),
+          };
+          return;
+        }
+      }
+    }
+    yield { type: 'done', billing: 'api' };
+  } catch (err) {
+    yield { type: 'error', message: (err as Error).message };
+  }
+}

--- a/apps/daemon/src/http/providers.test.ts
+++ b/apps/daemon/src/http/providers.test.ts
@@ -61,3 +61,78 @@ describe('GET /providers/:id/status', () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe('POST /providers/:id/login', () => {
+  it('returns 405 when provider does not support login (cli-passthrough)', async () => {
+    const app = appWith(fakeProvider());
+    const res = await app.request('/providers/anthropic-claude-cli/login', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(405);
+  });
+
+  it('forwards the body to provider.login and returns 200', async () => {
+    const captured: unknown[] = [];
+    const app = appWith(
+      fakeProvider({
+        authMode: 'apiKey',
+        login: async (input) => {
+          captured.push(input);
+        },
+      }),
+    );
+    const res = await app.request('/providers/anthropic-claude-cli/login', {
+      method: 'POST',
+      body: JSON.stringify({ apiKey: 'sk-test' }),
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(200);
+    expect(captured).toEqual([{ apiKey: 'sk-test' }]);
+  });
+
+  it('returns 400 when provider.login throws', async () => {
+    const app = appWith(
+      fakeProvider({
+        authMode: 'apiKey',
+        login: async () => {
+          throw new Error('apiKey required');
+        },
+      }),
+    );
+    const res = await app.request('/providers/anthropic-claude-cli/login', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /providers/:id/credential', () => {
+  it('returns 405 when provider does not support logout', async () => {
+    const app = appWith(fakeProvider());
+    const res = await app.request('/providers/anthropic-claude-cli/credential', {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(405);
+  });
+
+  it('calls provider.logout and returns 204', async () => {
+    let calls = 0;
+    const app = appWith(
+      fakeProvider({
+        authMode: 'apiKey',
+        logout: async () => {
+          calls += 1;
+        },
+      }),
+    );
+    const res = await app.request('/providers/anthropic-claude-cli/credential', {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(204);
+    expect(calls).toBe(1);
+  });
+});

--- a/apps/daemon/src/http/providers.ts
+++ b/apps/daemon/src/http/providers.ts
@@ -24,5 +24,37 @@ export function providersRouter(registry: ProviderRegistry): Hono {
     return c.json(await provider.status());
   });
 
+  app.post('/:id/login', async (c) => {
+    const provider = registry.get(c.req.param('id'));
+    if (!provider) {
+      return c.json({ error: 'unknown provider' }, 404);
+    }
+    if (!provider.login) {
+      return c.json(
+        { error: 'login not supported', authMode: provider.authMode },
+        405,
+      );
+    }
+    const body = await c.req.json().catch(() => ({}));
+    try {
+      await provider.login(body);
+      return c.json({ ok: true });
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 400);
+    }
+  });
+
+  app.delete('/:id/credential', async (c) => {
+    const provider = registry.get(c.req.param('id'));
+    if (!provider) {
+      return c.json({ error: 'unknown provider' }, 404);
+    }
+    if (!provider.logout) {
+      return c.json({ error: 'logout not supported' }, 405);
+    }
+    await provider.logout();
+    return c.body(null, 204);
+  });
+
   return app;
 }

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono';
 import { ProviderRegistry } from './providers/registry';
 import { claudeCliProvider } from './providers/adapters/claude-cli';
+import { openaiProvider } from './providers/adapters/openai';
+import { CredentialStore } from './providers/credentials';
 import { providersRouter } from './http/providers';
 import { chatRouter } from './http/chat';
 
@@ -18,9 +20,12 @@ export function buildApp(opts: BuildAppOptions = {}): Hono {
   return app;
 }
 
-export function createDefaultRegistry(): ProviderRegistry {
+export function createDefaultRegistry(
+  credentials: CredentialStore = new CredentialStore(),
+): ProviderRegistry {
   const r = new ProviderRegistry();
   r.register(claudeCliProvider());
+  r.register(openaiProvider(credentials));
   return r;
 }
 

--- a/apps/daemon/src/providers/adapters/openai.test.ts
+++ b/apps/daemon/src/providers/adapters/openai.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CredentialStore } from '../credentials';
+import { openaiProvider } from './openai';
+
+let dir: string;
+let store: CredentialStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'atlas-openai-'));
+  store = new CredentialStore(join(dir, 'credentials.json'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('openaiProvider', () => {
+  it('reports loggedIn=false when no credential is stored', async () => {
+    const provider = openaiProvider(store);
+    const status = await provider.status();
+    expect(status.loggedIn).toBe(false);
+  });
+
+  it('reports loggedIn=true when a credential is stored', async () => {
+    await store.set('openai', { apiKey: 'sk-test' });
+    const provider = openaiProvider(store);
+    const status = await provider.status();
+    expect(status.loggedIn).toBe(true);
+  });
+
+  it('login validates that apiKey is a non-empty string', async () => {
+    const provider = openaiProvider(store);
+    await expect(provider.login!({})).rejects.toThrow();
+    await expect(provider.login!({ apiKey: '' })).rejects.toThrow();
+    expect(await store.get('openai')).toBeUndefined();
+  });
+
+  it('login persists apiKey + optional baseUrl', async () => {
+    const provider = openaiProvider(store);
+    await provider.login!({ apiKey: 'sk-real', baseUrl: 'https://api.qwen.com/v1' });
+    expect(await store.get('openai')).toEqual({
+      apiKey: 'sk-real',
+      baseUrl: 'https://api.qwen.com/v1',
+    });
+  });
+
+  it('logout removes the stored credential', async () => {
+    const provider = openaiProvider(store);
+    await provider.login!({ apiKey: 'sk-real' });
+    await provider.logout!();
+    expect(await store.get('openai')).toBeUndefined();
+  });
+
+  it('chat yields an error event when no credential is configured', async () => {
+    const provider = openaiProvider(store);
+    const events: Array<{ type: string; message?: string }> = [];
+    for await (const ev of provider.chat({
+      providerId: 'openai',
+      messages: [{ role: 'user', content: 'hi' }],
+    })) {
+      events.push(ev as { type: string; message?: string });
+    }
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe('error');
+    expect(events[0]?.message).toContain('not logged in');
+  });
+});

--- a/apps/daemon/src/providers/adapters/openai.ts
+++ b/apps/daemon/src/providers/adapters/openai.ts
@@ -1,0 +1,78 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { z } from 'zod';
+import { runNativeLoop } from '../../agent/loop';
+import type {
+  AgentEvent,
+  ChatRequest,
+  Provider,
+  ProviderStatus,
+} from '../types';
+import type { CredentialStore } from '../credentials';
+
+const PROVIDER_KEY = 'openai';
+
+const loginSchema = z.object({
+  apiKey: z.string().min(1, 'apiKey is required'),
+  baseUrl: z.string().url().optional(),
+});
+
+type StoredCredential = z.infer<typeof loginSchema>;
+
+async function readCredential(
+  store: CredentialStore,
+): Promise<StoredCredential | undefined> {
+  const raw = await store.get(PROVIDER_KEY);
+  if (!raw || typeof raw !== 'object') return undefined;
+  const parsed = loginSchema.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function openaiProvider(store: CredentialStore): Provider {
+  const status = async (): Promise<ProviderStatus> => {
+    const cred = await readCredential(store);
+    if (!cred) return { loggedIn: false };
+    return {
+      loggedIn: true,
+      ...(cred.baseUrl ? { detail: `baseUrl: ${cred.baseUrl}` } : {}),
+    };
+  };
+
+  const chat = async function* (
+    req: ChatRequest,
+  ): AsyncIterable<AgentEvent> {
+    const cred = await readCredential(store);
+    if (!cred) {
+      yield { type: 'error', message: 'openai not logged in' };
+      return;
+    }
+    const factory = createOpenAI({
+      apiKey: cred.apiKey,
+      ...(cred.baseUrl && { baseURL: cred.baseUrl }),
+    });
+    const model = factory(req.model ?? 'gpt-4o-mini');
+    yield* runNativeLoop({
+      model,
+      messages: req.messages,
+      ...(req.signal && { signal: req.signal }),
+    });
+  };
+
+  const login = async (input: unknown): Promise<void> => {
+    const parsed = loginSchema.parse(input);
+    await store.set(PROVIDER_KEY, parsed);
+  };
+
+  const logout = async (): Promise<void> => {
+    await store.delete(PROVIDER_KEY);
+  };
+
+  return {
+    id: 'openai',
+    displayName: 'OpenAI',
+    authMode: 'apiKey',
+    status,
+    chat,
+    login,
+    logout,
+  };
+}

--- a/apps/daemon/src/providers/types.ts
+++ b/apps/daemon/src/providers/types.ts
@@ -1,4 +1,4 @@
-export type ProviderId = 'anthropic-claude-cli';
+export type ProviderId = 'anthropic-claude-cli' | 'openai';
 
 export type ChatMessage = {
   role: 'user' | 'assistant' | 'system';
@@ -44,4 +44,8 @@ export type Provider = {
   authMode: AuthMode;
   status(): Promise<ProviderStatus>;
   chat(req: ChatRequest): AsyncIterable<AgentEvent>;
+  /** Persist credentials. Throw on invalid input. Undefined = login not supported. */
+  login?(input: unknown): Promise<void>;
+  /** Clear credentials. Undefined = logout not supported. */
+  logout?(): Promise<void>;
 };

--- a/bun.lock
+++ b/bun.lock
@@ -12,17 +12,28 @@
     "apps/daemon": {
       "name": "@atlas/daemon",
       "dependencies": {
+        "@ai-sdk/openai": "^3.0.54",
         "@anthropic-ai/claude-agent-sdk": "^0.2.123",
+        "ai": "^6.0.170",
         "hono": "^4.6.0",
         "zod": "^4.4.1",
       },
       "devDependencies": {
+        "@ai-sdk/provider": "^3.0.9",
         "@types/bun": "latest",
         "typescript": "^5.7.0",
       },
     },
   },
   "packages": {
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.105", "", { "dependencies": { "@ai-sdk/provider": "3.0.9", "@ai-sdk/provider-utils": "4.0.24", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-XpERadvLMHkYGJO4hz1Sw7Y9J705Iex48TmdZLdZdaPiFFtVgiA9qhXugLUWGAxdlXU/2N6ipoPSOwfnULZbXw=="],
+
+    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.54", "", { "dependencies": { "@ai-sdk/provider": "3.0.9", "@ai-sdk/provider-utils": "4.0.24" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-j1qrNe/ebUKuE+fETzS+CVnczs11jQBR9y9M6aoKtJZAosg6SZnPC1Bb92e2u6yaSK+88TZoFhiY67uYphPitw=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.9", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-/ngMKqKdL9dSlY/eQ3NFDzzFyw0Hix+cbFFlyuKEKcOgpHdBt/spKUvX/i0wGrDLFPYJeVvv3N0j92LxWRL7yQ=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.24", "", { "dependencies": { "@ai-sdk/provider": "3.0.9", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oXIw1oLmuBILuvHgSj6w5LOV8oSnFRouPSv0MGkG9sRMeukZ9JnMF17kldaRQaRq8lSJIxo6aS3NzWlVmSb+4Q=="],
+
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.123", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.123", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.123", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.123", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.123" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-a4TysYoR9DBdkM9Uwh4J5ub7TwKmRPe5hFiWh4En+IKC+qkk5UFkxFM22c//cZjYZKynHX0ah2t6LUqb+najYA=="],
 
     "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.123", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tYAXCjlXZQklsUs0J//gip3fZQRzhlH5OCgvNXV70qe7A1iiwHqO2KPGvEHV1L+deEKQoMZmTaCOrQpN6zju3w=="],
@@ -51,6 +62,10 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "https://registry.npmmirror.com/@turbo/darwin-64/-/darwin-64-2.9.6.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
 
     "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.6", "https://registry.npmmirror.com/@turbo/darwin-arm64/-/darwin-arm64-2.9.6.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw=="],
@@ -67,7 +82,11 @@
 
     "@types/node": ["@types/node@25.6.0", "https://registry.npmmirror.com/@types/node/-/node-25.6.0.tgz", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ai": ["ai@6.0.170", "", { "dependencies": { "@ai-sdk/gateway": "3.0.105", "@ai-sdk/provider": "3.0.9", "@ai-sdk/provider-utils": "4.0.24", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-FWTKeGGDRcYJtPWIrdZDSuvOW5LCjI2NZUJmaml8OTOaPEsXnFdFvmawCXbT+wTGxyWKJTgZ9sZtCjbJsmjM2Q=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -162,6 +181,8 @@
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -27,11 +27,13 @@ atlas/
 │           ├── index.ts        # buildApp + createDefaultRegistry（不带 IO 副作用）
 │           ├── server.ts       # Bun.serve 启动入口
 │           ├── http/           # HTTP 路由：/chat、/providers、SSE 编码
+│           ├── agent/          # native agent loop（Vercel AI SDK），非 Claude 路径用
+│           │   └── loop.ts
 │           └── providers/      # provider 抽象 + 凭据存储 + 各家 adapter
 │               ├── types.ts
 │               ├── registry.ts
 │               ├── credentials.ts
-│               └── adapters/   # 每家 provider 一个文件，例 claude-cli.ts
+│               └── adapters/   # 每家 provider 一个文件：claude-cli.ts / openai.ts
 └── docs/                       # 项目文档
     ├── CLAUDE.md               # docs/ 职责说明（工作目录在 docs/ 下时自动加载）
     ├── architecture/


### PR DESCRIPTION
## Summary

接力 #5 落下的双轨架构，本 PR 把第二条路径 **native agent loop** 立起来，并接入第一个走 native loop 的 provider —— OpenAI（API key 模式）。Atlas 至此对两类用户都打通了 chat 通路：

- 已在本机登录 \`claude\` CLI 的用户：用 Claude 订阅
- 持有 OpenAI / OpenAI 兼容（Qwen / GLM / Kimi / DeepSeek）API key 的用户：粘贴 key 即用

## Changes

### Native agent loop（\`apps/daemon/src/agent/loop.ts\`）
封装 Vercel AI SDK 的 \`streamText\`，把 \`fullStream\` 事件归一成 Atlas 的 \`AgentEvent\`：
- \`text-delta\` → \`text-delta\`
- \`tool-call\` / \`tool-result\` / \`tool-error\` → \`tool-call\` / \`tool-result(ok=true|false)\`
- \`finish\` → \`done\`，携带归一化后的 usage
- \`error\` / \`abort\` → \`error\`

与 Claude SDK passthrough 输出**同一种 SSE 流**，前端无感切换。

### OpenAI provider（\`apps/daemon/src/providers/adapters/openai.ts\`）
- \`authMode: 'apiKey'\`
- \`chat()\` 从 \`CredentialStore\` 读 apiKey + 可选 baseUrl，\`createOpenAI(...)\` 构造 model，委托给 \`runNativeLoop\`
- \`login(input)\` zod 校验 \`{ apiKey, baseUrl? }\` 后写入凭据；\`logout()\` 删除凭据
- 预留 \`baseUrl\` 是为下个 issue 接 Qwen / GLM / Kimi / DeepSeek 做铺垫——这几家都是 OpenAI 兼容协议，**一份 adapter 配置化复用**，不重复造轮子

### Provider 协议扩展
\`Provider\` 增加可选 \`login(input)\` / \`logout()\`，让各家 adapter 自己掌握凭据字段与持久化方式；HTTP 层不再需要硬编码 schema。

### 新增 HTTP 端点
- \`POST /providers/:id/login\`：转发 body 给 \`provider.login\`；无 login 返 405；login throw 返 400
- \`DELETE /providers/:id/credential\`：调 \`provider.logout\`；无 logout 返 405

### 测试
\`ai/test\` 的 \`MockLanguageModelV3\` + \`simulateReadableStream\` 喂手写的 V3 stream parts 给 \`streamText\`，验证事件映射不依赖真 OpenAI API。devDep 加 \`@ai-sdk/provider\` 拿 \`LanguageModelV3StreamPart\` 类型给测试用。

## Test plan

- [ ] \`bun --cwd apps/daemon test\` 28 用例全绿
- [ ] \`bun --cwd apps/daemon run check\` 类型干净
- [ ] \`bun --cwd apps/daemon dev\` 启动后：
  - [ ] \`curl localhost:3001/providers\` 列出 \`anthropic-claude-cli\` + \`openai\`，openai \`status.loggedIn=false\`
  - [ ] \`curl -X POST localhost:3001/providers/openai/login -d '{}'\` → 400
  - [ ] \`curl -X POST localhost:3001/providers/openai/login -d '{\"apiKey\":\"sk-real\"}'\` → 200
  - [ ] \`curl localhost:3001/providers/openai/status\` → \`loggedIn:true\`
  - [ ] 真 key 下：\`curl -N -X POST localhost:3001/chat -H 'content-type: application/json' -d '{\"providerId\":\"openai\",\"model\":\"gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"reply: hello\"}]}'\` 流式输出
  - [ ] \`curl -X DELETE localhost:3001/providers/openai/credential\` → 204；status 复位 loggedIn:false

## Related

Closes #4