### PR TITLE
feat(daemon): add Kimi coding plan provider + enable CORS

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -9,6 +9,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.72",
     "@ai-sdk/openai": "^3.0.54",
     "@anthropic-ai/claude-agent-sdk": "^0.2.123",
     "ai": "^6.0.170",

--- a/apps/daemon/src/http/providers.test.ts
+++ b/apps/daemon/src/http/providers.test.ts
@@ -136,3 +136,32 @@ describe('DELETE /providers/:id/credential', () => {
     expect(calls).toBe(1);
   });
 });
+
+describe('CORS', () => {
+  it('reflects Origin on a real request so the renderer can read the response', async () => {
+    const app = appWith(fakeProvider());
+    const res = await app.request('/providers', {
+      headers: { Origin: 'http://localhost:5173' },
+    });
+    expect(res.headers.get('access-control-allow-origin')).toBe(
+      'http://localhost:5173',
+    );
+  });
+
+  it('answers OPTIONS preflight for POST /providers/:id/login', async () => {
+    const app = appWith(fakeProvider({ authMode: 'apiKey', login: async () => {} }));
+    const res = await app.request('/providers/anthropic-claude-cli/login', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'http://localhost:5173',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'content-type',
+      },
+    });
+    expect(res.status).toBeLessThan(300);
+    expect(res.headers.get('access-control-allow-origin')).toBe(
+      'http://localhost:5173',
+    );
+    expect(res.headers.get('access-control-allow-methods') ?? '').toContain('POST');
+  });
+});

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { cors } from 'hono/cors';
 import { ProviderRegistry } from './providers/registry';
 import { claudeCliProvider } from './providers/adapters/claude-cli';
 import { openaiProvider } from './providers/adapters/openai';
@@ -15,6 +16,7 @@ export function buildApp(opts: BuildAppOptions = {}): Hono {
   const registry = opts.registry ?? createDefaultRegistry();
 
   const app = new Hono();
+  app.use('*', cors({ origin: (o) => o, allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'] }));
   app.get('/health', (c) => c.json({ status: 'ok' }));
   app.route('/providers', providersRouter(registry));
   app.route('/chat', chatRouter(registry));

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { ProviderRegistry } from './providers/registry';
 import { claudeCliProvider } from './providers/adapters/claude-cli';
 import { openaiProvider } from './providers/adapters/openai';
+import { kimiProvider } from './providers/adapters/kimi';
 import { CredentialStore } from './providers/credentials';
 import { providersRouter } from './http/providers';
 import { chatRouter } from './http/chat';
@@ -26,6 +27,7 @@ export function createDefaultRegistry(
   const r = new ProviderRegistry();
   r.register(claudeCliProvider());
   r.register(openaiProvider(credentials));
+  r.register(kimiProvider(credentials));
   return r;
 }
 

--- a/apps/daemon/src/providers/adapters/kimi.test.ts
+++ b/apps/daemon/src/providers/adapters/kimi.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CredentialStore } from '../credentials';
+import { kimiProvider } from './kimi';
+
+let dir: string;
+let store: CredentialStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'atlas-kimi-'));
+  store = new CredentialStore(join(dir, 'credentials.json'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('kimiProvider', () => {
+  it('exposes Moonshot defaults via id/displayName/authMode', () => {
+    const provider = kimiProvider(store);
+    expect(provider.id).toBe('kimi');
+    expect(provider.authMode).toBe('apiKey');
+    expect(provider.displayName.toLowerCase()).toContain('kimi');
+  });
+
+  it('reports loggedIn=false when no credential is stored', async () => {
+    const provider = kimiProvider(store);
+    const status = await provider.status();
+    expect(status.loggedIn).toBe(false);
+  });
+
+  it('reports loggedIn=true when a credential is stored', async () => {
+    await store.set('kimi', { apiKey: 'sk-test' });
+    const provider = kimiProvider(store);
+    const status = await provider.status();
+    expect(status.loggedIn).toBe(true);
+  });
+
+  it('login validates that apiKey is a non-empty string', async () => {
+    const provider = kimiProvider(store);
+    await expect(provider.login!({})).rejects.toThrow();
+    await expect(provider.login!({ apiKey: '' })).rejects.toThrow();
+    expect(await store.get('kimi')).toBeUndefined();
+  });
+
+  it('login only persists apiKey — baseUrl is hardcoded to the coding plan endpoint', async () => {
+    const provider = kimiProvider(store);
+    await provider.login!({
+      apiKey: 'sk-real',
+      baseUrl: 'https://elsewhere.example/v1',
+    });
+    expect(await store.get('kimi')).toEqual({ apiKey: 'sk-real' });
+  });
+
+  it('logout removes the stored credential', async () => {
+    const provider = kimiProvider(store);
+    await provider.login!({ apiKey: 'sk-real' });
+    await provider.logout!();
+    expect(await store.get('kimi')).toBeUndefined();
+  });
+
+  it('chat yields an error event when no credential is configured', async () => {
+    const provider = kimiProvider(store);
+    const events: Array<{ type: string; message?: string }> = [];
+    for await (const ev of provider.chat({
+      providerId: 'kimi',
+      messages: [{ role: 'user', content: 'hi' }],
+    })) {
+      events.push(ev as { type: string; message?: string });
+    }
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe('error');
+    expect(events[0]?.message).toContain('not logged in');
+  });
+});

--- a/apps/daemon/src/providers/adapters/kimi.ts
+++ b/apps/daemon/src/providers/adapters/kimi.ts
@@ -1,0 +1,73 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { z } from 'zod';
+import { runNativeLoop } from '../../agent/loop';
+import type {
+  AgentEvent,
+  ChatRequest,
+  Provider,
+  ProviderStatus,
+} from '../types';
+import type { CredentialStore } from '../credentials';
+
+const PROVIDER_KEY = 'kimi';
+const BASE_URL = 'https://api.kimi.com/coding/v1';
+const DEFAULT_MODEL = 'kimi-for-coding';
+
+const loginSchema = z.object({
+  apiKey: z.string().min(1, 'apiKey is required'),
+});
+
+type StoredCredential = z.infer<typeof loginSchema>;
+
+async function readCredential(
+  store: CredentialStore,
+): Promise<StoredCredential | undefined> {
+  const raw = await store.get(PROVIDER_KEY);
+  if (!raw || typeof raw !== 'object') return undefined;
+  const parsed = loginSchema.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function kimiProvider(store: CredentialStore): Provider {
+  const status = async (): Promise<ProviderStatus> => {
+    const cred = await readCredential(store);
+    if (!cred) return { loggedIn: false };
+    return { loggedIn: true };
+  };
+
+  const chat = async function* (
+    req: ChatRequest,
+  ): AsyncIterable<AgentEvent> {
+    const cred = await readCredential(store);
+    if (!cred) {
+      yield { type: 'error', message: 'kimi not logged in' };
+      return;
+    }
+    const factory = createAnthropic({ apiKey: cred.apiKey, baseURL: BASE_URL });
+    const model = factory(req.model ?? DEFAULT_MODEL);
+    yield* runNativeLoop({
+      model,
+      messages: req.messages,
+      ...(req.signal && { signal: req.signal }),
+    });
+  };
+
+  const login = async (input: unknown): Promise<void> => {
+    const parsed = loginSchema.parse(input);
+    await store.set(PROVIDER_KEY, parsed);
+  };
+
+  const logout = async (): Promise<void> => {
+    await store.delete(PROVIDER_KEY);
+  };
+
+  return {
+    id: 'kimi',
+    displayName: 'Kimi (Moonshot Coding Plan)',
+    authMode: 'apiKey',
+    status,
+    chat,
+    login,
+    logout,
+  };
+}

--- a/apps/daemon/src/providers/types.ts
+++ b/apps/daemon/src/providers/types.ts
@@ -1,4 +1,4 @@
-export type ProviderId = 'anthropic-claude-cli' | 'openai';
+export type ProviderId = 'anthropic-claude-cli' | 'openai' | 'kimi';
 
 export type ChatMessage = {
   role: 'user' | 'assistant' | 'system';

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { SettingsSheet } from './components/SettingsSheet';
 const DEFAULT_MODEL: Record<string, string> = {
   'anthropic-claude-cli': 'claude-sonnet-4-5',
   openai: 'gpt-4o-mini',
+  kimi: 'kimi-for-coding',
 };
 
 const client = new DaemonClient();

--- a/apps/desktop/src/renderer/components/ProviderCard.tsx
+++ b/apps/desktop/src/renderer/components/ProviderCard.tsx
@@ -102,12 +102,14 @@ function ApiKeyCard({
     setError(null);
   };
 
+  const showBaseUrl = provider.id !== 'kimi';
+
   const submit = async () => {
     setBusy(true);
     setError(null);
     try {
       const payload: { apiKey: string; baseUrl?: string } = { apiKey };
-      if (baseUrl.trim()) payload.baseUrl = baseUrl.trim();
+      if (showBaseUrl && baseUrl.trim()) payload.baseUrl = baseUrl.trim();
       await onLogin(payload);
       reset();
       setEditing(false);
@@ -152,8 +154,9 @@ function ApiKeyCard({
 
       {editing ? (
         <div className="provider-card-body">
-          Paste an API key. Optionally set a custom base URL for OpenAI-compatible
-          providers (Qwen, GLM, Kimi, DeepSeek, Ollama).
+          {showBaseUrl
+            ? 'Paste an API key. Optionally set a custom base URL for OpenAI-compatible providers (Qwen, GLM, DeepSeek, Ollama).'
+            : 'Paste your Kimi coding plan API key — the endpoint is fixed.'}
           <div className="field">
             <label htmlFor={`${provider.id}-apikey`}>API key</label>
             <input
@@ -165,18 +168,20 @@ function ApiKeyCard({
               onChange={(e) => setApiKey(e.target.value)}
             />
           </div>
-          <div className="field">
-            <label htmlFor={`${provider.id}-baseurl`}>
-              Base URL <span className="hint">(optional)</span>
-            </label>
-            <input
-              id={`${provider.id}-baseurl`}
-              type="text"
-              placeholder="https://api.openai.com/v1"
-              value={baseUrl}
-              onChange={(e) => setBaseUrl(e.target.value)}
-            />
-          </div>
+          {showBaseUrl && (
+            <div className="field">
+              <label htmlFor={`${provider.id}-baseurl`}>
+                Base URL <span className="hint">(optional)</span>
+              </label>
+              <input
+                id={`${provider.id}-baseurl`}
+                type="text"
+                placeholder="https://api.openai.com/v1"
+                value={baseUrl}
+                onChange={(e) => setBaseUrl(e.target.value)}
+              />
+            </div>
+          )}
           {error && <div className="field err">{error}</div>}
           <div className="row-actions">
             {connected && (

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
     "apps/daemon": {
       "name": "@atlas/daemon",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.72",
         "@ai-sdk/openai": "^3.0.54",
         "@anthropic-ai/claude-agent-sdk": "^0.2.123",
         "ai": "^6.0.170",
@@ -44,6 +45,8 @@
     },
   },
   "packages": {
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.72", "", { "dependencies": { "@ai-sdk/provider": "3.0.9", "@ai-sdk/provider-utils": "4.0.24" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-t0j9mggxylA9uP0hi12NlRk2npYh4QkE7JIpws2MdV/18QzHcsT6+TNGIjbOPayLQDjrmRKx78Ym7iZkg9qRxQ=="],
+
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.105", "", { "dependencies": { "@ai-sdk/provider": "3.0.9", "@ai-sdk/provider-utils": "4.0.24", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-XpERadvLMHkYGJO4hz1Sw7Y9J705Iex48TmdZLdZdaPiFFtVgiA9qhXugLUWGAxdlXU/2N6ipoPSOwfnULZbXw=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.54", "", { "dependencies": { "@ai-sdk/provider": "3.0.9", "@ai-sdk/provider-utils": "4.0.24" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-j1qrNe/ebUKuE+fETzS+CVnczs11jQBR9y9M6aoKtJZAosg6SZnPC1Bb92e2u6yaSK+88TZoFhiY67uYphPitw=="],

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -33,7 +33,7 @@ atlas/
 │   │           ├── types.ts
 │   │           ├── registry.ts
 │   │           ├── credentials.ts
-│   │           └── adapters/   # 每家 provider 一个文件：claude-cli.ts / openai.ts
+│   │           └── adapters/   # 每家 provider 一个文件：claude-cli.ts / openai.ts / kimi.ts
 │   └── desktop/                # 桌面端（Electron + Vite + React）
 │       ├── electron.vite.config.ts
 │       ├── index.html


### PR DESCRIPTION
## Summary
为 daemon 接入 Moonshot 的 Kimi coding plan，作为第一个 Anthropic-Messages 协议的 provider；同时给 daemon 加上 CORS，让 Electron renderer 在跨源（5173 → 3001）下能正常拉到 `/providers`，修掉 settings 里 "Can't reach the daemon" 的常驻提示。

## Changes
**Kimi provider**
- `apps/daemon/src/providers/adapters/kimi.ts`: 新 adapter，走 `@ai-sdk/anthropic`，`baseURL=https://api.kimi.com/coding/v1`、默认模型 `kimi-for-coding`、登录只收 `apiKey`
- `apps/daemon/src/providers/types.ts`: `ProviderId` 增加 `'kimi'`
- `apps/daemon/src/index.ts`: 注册到默认 registry
- `apps/daemon/package.json` + `bun.lock`: 加 `@ai-sdk/anthropic@^3.0.72`
- `apps/desktop/src/renderer/App.tsx`: 默认模型映射加 `kimi: kimi-for-coding`
- `apps/desktop/src/renderer/components/ProviderCard.tsx`: kimi 卡片隐藏 baseUrl 输入并换文案
- `apps/daemon/src/providers/adapters/kimi.test.ts`: 7 个 case（id/auth、status、login 校验、login 只持久化 apiKey、logout、未登录错误事件）
- `docs/project-structure.md`: adapter 示例补 `kimi.ts`

**CORS**
- `apps/daemon/src/index.ts`: 加 `cors({ origin: (o) => o, allowMethods: [...] })`，回显 Origin
- `apps/daemon/src/http/providers.test.ts`: 加 simple GET ACAO 头 + OPTIONS 预检 2 个测试

## Test plan
- [x] `bun --cwd apps/daemon test` — 37/37 通过
- [x] `bun --cwd apps/daemon run check` — typecheck 干净
- [x] `bun --cwd apps/desktop run check` — typecheck 干净
- [x] `curl -H "Origin: http://localhost:5173" http://localhost:3001/providers` 看到 `Access-Control-Allow-Origin: http://localhost:5173`
- [ ] desktop 设置面板里 Kimi 卡片只剩 API key 输入；填入有效 key → Connect → status 变 Connected
- [ ] 选中 Kimi 发一条消息，daemon 走 `https://api.kimi.com/coding/v1/messages`，看到流式回复