### PR TITLE
feat(daemon): add config module and per-session persistence

### DIFF
--- a/apps/daemon/src/config/config.test.ts
+++ b/apps/daemon/src/config/config.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadConfig, resolveAtlasHome } from './index';
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'atlas-cfg-'));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('resolveAtlasHome', () => {
+  it('falls back to ~/.atlas when ATLAS_HOME is unset', () => {
+    expect(resolveAtlasHome({})).toBe(join(homedir(), '.atlas'));
+  });
+
+  it('honours ATLAS_HOME when set', () => {
+    expect(resolveAtlasHome({ ATLAS_HOME: '/tmp/xyz' })).toBe('/tmp/xyz');
+  });
+
+  it('treats empty ATLAS_HOME as unset', () => {
+    expect(resolveAtlasHome({ ATLAS_HOME: '' })).toBe(join(homedir(), '.atlas'));
+  });
+});
+
+describe('loadConfig', () => {
+  it('returns defaults when config.json is absent', async () => {
+    const cfg = await loadConfig(home);
+    expect(cfg.home).toBe(home);
+    expect(cfg.daemon.port).toBe(3001);
+    expect(cfg.defaults).toEqual({});
+    expect(cfg.sessions.dir).toBe(join(home, 'sessions'));
+    expect(cfg.credentialsPath).toBe(join(home, 'credentials.json'));
+  });
+
+  it('reads daemon.port from config.json', async () => {
+    writeFileSync(
+      join(home, 'config.json'),
+      JSON.stringify({ daemon: { port: 4000 } }),
+    );
+    const cfg = await loadConfig(home);
+    expect(cfg.daemon.port).toBe(4000);
+  });
+
+  it('resolves a relative sessions.dir against home', async () => {
+    writeFileSync(
+      join(home, 'config.json'),
+      JSON.stringify({ sessions: { dir: 'data/chats' } }),
+    );
+    const cfg = await loadConfig(home);
+    expect(cfg.sessions.dir).toBe(join(home, 'data/chats'));
+  });
+
+  it('keeps an absolute sessions.dir as-is', async () => {
+    const abs = mkdtempSync(join(tmpdir(), 'atlas-sessions-'));
+    writeFileSync(
+      join(home, 'config.json'),
+      JSON.stringify({ sessions: { dir: abs } }),
+    );
+    const cfg = await loadConfig(home);
+    expect(cfg.sessions.dir).toBe(abs);
+    rmSync(abs, { recursive: true, force: true });
+  });
+
+  it('exposes defaults.providerId and model when set', async () => {
+    writeFileSync(
+      join(home, 'config.json'),
+      JSON.stringify({ defaults: { providerId: 'kimi', model: 'k2' } }),
+    );
+    const cfg = await loadConfig(home);
+    expect(cfg.defaults.providerId).toBe('kimi');
+    expect(cfg.defaults.model).toBe('k2');
+  });
+
+  it('throws a clear error when config.json is malformed', async () => {
+    writeFileSync(join(home, 'config.json'), '{not json');
+    await expect(loadConfig(home)).rejects.toThrow(/config\.json/);
+  });
+});

--- a/apps/daemon/src/config/index.ts
+++ b/apps/daemon/src/config/index.ts
@@ -1,0 +1,64 @@
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { isAbsolute, join } from 'node:path';
+
+export type AppConfig = {
+  home: string;
+  daemon: { port: number };
+  defaults: { providerId?: string; model?: string };
+  sessions: { dir: string };
+  credentialsPath: string;
+};
+
+const DEFAULT_PORT = 3001;
+
+export function resolveAtlasHome(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const override = env.ATLAS_HOME;
+  if (override && override.length > 0) return override;
+  return join(homedir(), '.atlas');
+}
+
+export async function loadConfig(home?: string): Promise<AppConfig> {
+  const root = home ?? resolveAtlasHome();
+  const file = join(root, 'config.json');
+  const raw = await readFile(file, 'utf8').catch((err) => {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  });
+
+  let parsed: RawConfig = {};
+  if (raw !== null) {
+    try {
+      parsed = JSON.parse(raw) as RawConfig;
+    } catch (err) {
+      throw new Error(
+        `failed to parse ${file}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  const sessionsDir = parsed.sessions?.dir
+    ? isAbsolute(parsed.sessions.dir)
+      ? parsed.sessions.dir
+      : join(root, parsed.sessions.dir)
+    : join(root, 'sessions');
+
+  return {
+    home: root,
+    daemon: { port: parsed.daemon?.port ?? DEFAULT_PORT },
+    defaults: {
+      providerId: parsed.defaults?.providerId,
+      model: parsed.defaults?.model,
+    },
+    sessions: { dir: sessionsDir },
+    credentialsPath: join(root, 'credentials.json'),
+  };
+}
+
+type RawConfig = {
+  daemon?: { port?: number };
+  defaults?: { providerId?: string; model?: string };
+  sessions?: { dir?: string };
+};

--- a/apps/daemon/src/http/chat.test.ts
+++ b/apps/daemon/src/http/chat.test.ts
@@ -1,68 +1,177 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { buildApp } from '../index';
-import type { Provider } from '../providers/types';
+import type { Provider, ChatRequest, AgentEvent } from '../providers/types';
 import { ProviderRegistry } from '../providers/registry';
+import { FileSessionStore } from '../sessions/store';
 
-function fakeProvider(): Provider {
+const FIXED_REPLY = 'hello world';
+
+type CallLog = { messages: ChatRequest['messages']; model?: string };
+
+function fakeProvider(log: CallLog[] = []): Provider {
   return {
     id: 'anthropic-claude-cli',
     displayName: 'Claude (fake)',
     authMode: 'cli-passthrough',
     status: async () => ({ loggedIn: true }),
-    chat: async function* () {
-      yield { type: 'text-delta', text: 'hello ' };
-      yield { type: 'text-delta', text: 'world' };
-      yield { type: 'done' };
+    chat: function (req: ChatRequest): AsyncIterable<AgentEvent> {
+      log.push({ messages: req.messages, model: req.model });
+      return (async function* () {
+        yield { type: 'text-delta', text: 'hello ' };
+        yield { type: 'text-delta', text: 'world' };
+        yield { type: 'done' };
+      })();
     },
   };
 }
 
-function appWithFake(): ReturnType<typeof buildApp> {
-  const registry = new ProviderRegistry();
-  registry.register(fakeProvider());
-  return buildApp({ registry });
-}
+let dir: string;
+let store: FileSessionStore;
+let registry: ProviderRegistry;
+let calls: CallLog[];
+let app: ReturnType<typeof buildApp>;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'atlas-chat-'));
+  store = new FileSessionStore(dir);
+  registry = new ProviderRegistry();
+  calls = [];
+  registry.register(fakeProvider(calls));
+  app = buildApp({ registry, sessions: store });
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
 
 describe('POST /chat', () => {
-  it('returns 400 when body is invalid', async () => {
-    const app = appWithFake();
+  it('returns 400 when message is missing', async () => {
     const res = await app.request('/chat', {
       method: 'POST',
-      body: '{}',
+      body: JSON.stringify({ providerId: 'anthropic-claude-cli' }),
       headers: { 'content-type': 'application/json' },
     });
     expect(res.status).toBe(400);
   });
 
-  it('returns 404 when providerId is unknown', async () => {
-    const app = appWithFake();
+  it('returns 400 when neither sessionId nor providerId is given', async () => {
+    const res = await app.request('/chat', {
+      method: 'POST',
+      body: JSON.stringify({ message: { role: 'user', content: 'hi' } }),
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when providerId is unknown (new session path)', async () => {
     const res = await app.request('/chat', {
       method: 'POST',
       body: JSON.stringify({
-        providerId: 'does-not-exist',
-        messages: [{ role: 'user', content: 'hi' }],
+        providerId: 'unknown',
+        message: { role: 'user', content: 'hi' },
       }),
       headers: { 'content-type': 'application/json' },
     });
     expect(res.status).toBe(404);
   });
 
-  it('streams SSE events for a known provider', async () => {
-    const app = appWithFake();
+  it('returns 404 when sessionId is unknown', async () => {
+    const res = await app.request('/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        sessionId: 'does-not-exist',
+        message: { role: 'user', content: 'hi' },
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('creates a new session when sessionId is omitted', async () => {
     const res = await app.request('/chat', {
       method: 'POST',
       body: JSON.stringify({
         providerId: 'anthropic-claude-cli',
-        messages: [{ role: 'user', content: 'hi' }],
+        message: { role: 'user', content: 'hi' },
       }),
       headers: { 'content-type': 'application/json' },
     });
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type') ?? '').toContain('text/event-stream');
+    const sid = res.headers.get('x-atlas-session-id');
+    expect(sid).toBeTruthy();
+    await res.text();
+    const persisted = await store.get(sid!);
+    expect(persisted?.messages).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: FIXED_REPLY },
+    ]);
+  });
+
+  it('streams SSE text-delta and done events', async () => {
+    const res = await app.request('/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerId: 'anthropic-claude-cli',
+        message: { role: 'user', content: 'hi' },
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
     const body = await res.text();
     expect(body).toContain('event: text-delta');
     expect(body).toContain('"text":"hello "');
     expect(body).toContain('"text":"world"');
     expect(body).toContain('event: done');
+  });
+
+  it('replays prior messages plus new user message to the provider on reuse', async () => {
+    const session = await store.create({ providerId: 'anthropic-claude-cli' });
+    await store.appendMessage(session.id, { role: 'user', content: 'turn 1' });
+    await store.appendMessage(session.id, {
+      role: 'assistant',
+      content: 'reply 1',
+    });
+
+    const res = await app.request('/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        sessionId: session.id,
+        message: { role: 'user', content: 'turn 2' },
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-atlas-session-id')).toBe(session.id);
+    await res.text();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.messages).toEqual([
+      { role: 'user', content: 'turn 1' },
+      { role: 'assistant', content: 'reply 1' },
+      { role: 'user', content: 'turn 2' },
+    ]);
+
+    const updated = await store.get(session.id);
+    expect(updated?.messages).toEqual([
+      { role: 'user', content: 'turn 1' },
+      { role: 'assistant', content: 'reply 1' },
+      { role: 'user', content: 'turn 2' },
+      { role: 'assistant', content: FIXED_REPLY },
+    ]);
+  });
+
+  it('rejects message with non-user role', async () => {
+    const res = await app.request('/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerId: 'anthropic-claude-cli',
+        message: { role: 'assistant', content: 'sneaky' },
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/apps/daemon/src/http/chat.ts
+++ b/apps/daemon/src/http/chat.ts
@@ -1,22 +1,24 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import type { ProviderRegistry } from '../providers/registry';
+import type { AgentEvent, ProviderId } from '../providers/types';
+import type { FileSessionStore, Session } from '../sessions/store';
 import { sseStream } from './sse';
 
 const chatRequestSchema = z.object({
-  providerId: z.string().min(1),
+  sessionId: z.string().min(1).optional(),
+  providerId: z.string().min(1).optional(),
   model: z.string().min(1).optional(),
-  messages: z
-    .array(
-      z.object({
-        role: z.enum(['user', 'assistant', 'system']),
-        content: z.string(),
-      }),
-    )
-    .min(1),
+  message: z.object({
+    role: z.literal('user'),
+    content: z.string().min(1),
+  }),
 });
 
-export function chatRouter(registry: ProviderRegistry): Hono {
+export function chatRouter(
+  registry: ProviderRegistry,
+  store: FileSessionStore,
+): Hono {
   const app = new Hono();
 
   app.post('/', async (c) => {
@@ -26,31 +28,78 @@ export function chatRouter(registry: ProviderRegistry): Hono {
       return c.json({ error: 'invalid request', issues: parsed.error.issues }, 400);
     }
 
-    const provider = registry.get(parsed.data.providerId);
-    if (!provider) {
-      return c.json({ error: `unknown providerId: ${parsed.data.providerId}` }, 404);
+    let session: Session;
+    if (parsed.data.sessionId) {
+      const existing = await store.get(parsed.data.sessionId);
+      if (!existing) return c.json({ error: 'session not found' }, 404);
+      session = existing;
+    } else {
+      if (!parsed.data.providerId) {
+        return c.json(
+          { error: 'providerId required when sessionId is omitted' },
+          400,
+        );
+      }
+      if (!registry.get(parsed.data.providerId)) {
+        return c.json({ error: `unknown providerId: ${parsed.data.providerId}` }, 404);
+      }
+      session = await store.create({
+        providerId: parsed.data.providerId,
+        model: parsed.data.model,
+      });
     }
+
+    const provider = registry.get(session.providerId);
+    if (!provider) {
+      return c.json({ error: `unknown providerId: ${session.providerId}` }, 404);
+    }
+
+    session = await store.appendMessage(session.id, parsed.data.message);
 
     const ac = new AbortController();
     c.req.raw.signal.addEventListener('abort', () => ac.abort(), { once: true });
 
-    const stream = sseStream(
-      provider.chat({
-        providerId: provider.id,
-        model: parsed.data.model,
-        messages: parsed.data.messages,
-        signal: ac.signal,
-      }),
-    );
+    const events = provider.chat({
+      providerId: provider.id as ProviderId,
+      model: parsed.data.model ?? session.model,
+      messages: session.messages,
+      signal: ac.signal,
+    });
 
-    return new Response(stream, {
+    const sessionId = session.id;
+    const persisted = persistAssistant(events, async (text) => {
+      if (text.length === 0) return;
+      await store.appendMessage(sessionId, { role: 'assistant', content: text });
+    });
+
+    return new Response(sseStream(persisted), {
       headers: {
         'content-type': 'text/event-stream; charset=utf-8',
         'cache-control': 'no-cache',
         connection: 'keep-alive',
+        'x-atlas-session-id': sessionId,
       },
     });
   });
 
   return app;
+}
+
+async function* persistAssistant(
+  source: AsyncIterable<AgentEvent>,
+  onComplete: (text: string) => Promise<void>,
+): AsyncIterable<AgentEvent> {
+  let buf = '';
+  try {
+    for await (const ev of source) {
+      if (ev.type === 'text-delta') buf += ev.text;
+      yield ev;
+    }
+  } finally {
+    try {
+      await onComplete(buf);
+    } catch (err) {
+      console.error('failed to persist assistant message:', err);
+    }
+  }
 }

--- a/apps/daemon/src/http/providers.test.ts
+++ b/apps/daemon/src/http/providers.test.ts
@@ -1,7 +1,21 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { buildApp } from '../index';
 import type { Provider } from '../providers/types';
 import { ProviderRegistry } from '../providers/registry';
+import { FileSessionStore } from '../sessions/store';
+
+let sessionsDir: string;
+
+beforeEach(() => {
+  sessionsDir = mkdtempSync(join(tmpdir(), 'atlas-providers-test-'));
+});
+
+afterEach(() => {
+  rmSync(sessionsDir, { recursive: true, force: true });
+});
 
 function fakeProvider(overrides: Partial<Provider> = {}): Provider {
   return {
@@ -19,7 +33,7 @@ function fakeProvider(overrides: Partial<Provider> = {}): Provider {
 function appWith(p: Provider): ReturnType<typeof buildApp> {
   const registry = new ProviderRegistry();
   registry.register(p);
-  return buildApp({ registry });
+  return buildApp({ registry, sessions: new FileSessionStore(sessionsDir) });
 }
 
 describe('GET /providers', () => {

--- a/apps/daemon/src/http/sessions.test.ts
+++ b/apps/daemon/src/http/sessions.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildApp } from '../index';
+import { ProviderRegistry } from '../providers/registry';
+import { FileSessionStore, type Session, type SessionSummary } from '../sessions/store';
+
+let dir: string;
+let store: FileSessionStore;
+let app: ReturnType<typeof buildApp>;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'atlas-sessions-http-'));
+  store = new FileSessionStore(dir);
+  app = buildApp({ registry: new ProviderRegistry(), sessions: store });
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('GET /sessions', () => {
+  it('returns [] when no sessions exist', async () => {
+    const res = await app.request('/sessions');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it('returns summaries (no messages) sorted by updatedAt desc', async () => {
+    const a = await store.create({ providerId: 'openai', title: 'A' });
+    await new Promise((r) => setTimeout(r, 5));
+    const b = await store.create({ providerId: 'openai', title: 'B' });
+    const res = await app.request('/sessions');
+    const json = (await res.json()) as SessionSummary[];
+    expect(json.map((s) => s.id)).toEqual([b.id, a.id]);
+    expect((json[0] as Record<string, unknown>).messages).toBeUndefined();
+  });
+});
+
+describe('POST /sessions', () => {
+  it('creates a session', async () => {
+    const res = await app.request('/sessions', {
+      method: 'POST',
+      body: JSON.stringify({ providerId: 'openai', model: 'gpt-4o', title: 'hi' }),
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Session;
+    expect(body.providerId).toBe('openai');
+    expect(body.model).toBe('gpt-4o');
+    expect(body.title).toBe('hi');
+    expect(body.messages).toEqual([]);
+    expect(await store.get(body.id)).toBeDefined();
+  });
+
+  it('returns 400 when providerId missing', async () => {
+    const res = await app.request('/sessions', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'no provider' }),
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /sessions/:id', () => {
+  it('returns the full session', async () => {
+    const s = await store.create({ providerId: 'openai' });
+    const res = await app.request(`/sessions/${s.id}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(s);
+  });
+
+  it('returns 404 when unknown', async () => {
+    const res = await app.request('/sessions/does-not-exist');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /sessions/:id', () => {
+  it('removes the session and returns 204', async () => {
+    const s = await store.create({ providerId: 'openai' });
+    const res = await app.request(`/sessions/${s.id}`, { method: 'DELETE' });
+    expect(res.status).toBe(204);
+    expect(await store.get(s.id)).toBeUndefined();
+  });
+
+  it('returns 204 even when unknown (idempotent)', async () => {
+    const res = await app.request('/sessions/nope', { method: 'DELETE' });
+    expect(res.status).toBe(204);
+  });
+});

--- a/apps/daemon/src/http/sessions.ts
+++ b/apps/daemon/src/http/sessions.ts
@@ -1,0 +1,38 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import type { FileSessionStore } from '../sessions/store';
+
+const createSchema = z.object({
+  providerId: z.string().min(1),
+  model: z.string().min(1).optional(),
+  title: z.string().optional(),
+});
+
+export function sessionsRouter(store: FileSessionStore): Hono {
+  const app = new Hono();
+
+  app.get('/', async (c) => c.json(await store.list()));
+
+  app.get('/:id', async (c) => {
+    const session = await store.get(c.req.param('id'));
+    if (!session) return c.json({ error: 'session not found' }, 404);
+    return c.json(session);
+  });
+
+  app.post('/', async (c) => {
+    const raw = await c.req.json().catch(() => null);
+    const parsed = createSchema.safeParse(raw);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid request', issues: parsed.error.issues }, 400);
+    }
+    const session = await store.create(parsed.data);
+    return c.json(session, 201);
+  });
+
+  app.delete('/:id', async (c) => {
+    await store.delete(c.req.param('id'));
+    return c.body(null, 204);
+  });
+
+  return app;
+}

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -5,21 +5,31 @@ import { claudeCliProvider } from './providers/adapters/claude-cli';
 import { openaiProvider } from './providers/adapters/openai';
 import { kimiProvider } from './providers/adapters/kimi';
 import { CredentialStore } from './providers/credentials';
+import { FileSessionStore } from './sessions/store';
 import { providersRouter } from './http/providers';
 import { chatRouter } from './http/chat';
+import { sessionsRouter } from './http/sessions';
 
 export type BuildAppOptions = {
-  registry?: ProviderRegistry;
+  registry: ProviderRegistry;
+  sessions: FileSessionStore;
 };
 
-export function buildApp(opts: BuildAppOptions = {}): Hono {
-  const registry = opts.registry ?? createDefaultRegistry();
-
+export function buildApp(opts: BuildAppOptions): Hono {
+  const { registry, sessions } = opts;
   const app = new Hono();
-  app.use('*', cors({ origin: (o) => o, allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'] }));
+  app.use(
+    '*',
+    cors({
+      origin: (o) => o,
+      allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+      exposeHeaders: ['x-atlas-session-id'],
+    }),
+  );
   app.get('/health', (c) => c.json({ status: 'ok' }));
   app.route('/providers', providersRouter(registry));
-  app.route('/chat', chatRouter(registry));
+  app.route('/chat', chatRouter(registry, sessions));
+  app.route('/sessions', sessionsRouter(sessions));
   return app;
 }
 
@@ -32,5 +42,3 @@ export function createDefaultRegistry(
   r.register(kimiProvider(credentials));
   return r;
 }
-
-export const app = buildApp();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1,7 +1,16 @@
-import { app } from './index';
+import { loadConfig } from './config';
+import { buildApp, createDefaultRegistry } from './index';
+import { CredentialStore } from './providers/credentials';
+import { FileSessionStore } from './sessions/store';
 
-const port = Number(process.env.PORT ?? 3001);
-console.log(`atlas daemon listening on :${port}`);
+const config = await loadConfig();
+const credentials = new CredentialStore(config.credentialsPath);
+const sessions = new FileSessionStore(config.sessions.dir);
+const registry = createDefaultRegistry(credentials);
+const app = buildApp({ registry, sessions });
+
+const port = Number(process.env.PORT ?? config.daemon.port);
+console.log(`atlas daemon listening on :${port} (home: ${config.home})`);
 
 export default {
   port,

--- a/apps/daemon/src/sessions/store.test.ts
+++ b/apps/daemon/src/sessions/store.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FileSessionStore } from './store';
+
+let dir: string;
+let store: FileSessionStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'atlas-sessions-'));
+  store = new FileSessionStore(dir);
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('FileSessionStore.create', () => {
+  it('creates a session with id, timestamps, and empty messages', async () => {
+    const s = await store.create({ providerId: 'openai' });
+    expect(s.id).toMatch(/.+/);
+    expect(s.providerId).toBe('openai');
+    expect(s.messages).toEqual([]);
+    expect(s.createdAt).toBe(s.updatedAt);
+    expect(s.title).toBe('');
+  });
+
+  it('persists model and title when provided', async () => {
+    const s = await store.create({
+      providerId: 'kimi',
+      model: 'k2',
+      title: 'hello',
+    });
+    expect(s.model).toBe('k2');
+    expect(s.title).toBe('hello');
+  });
+
+  it('writes one file per session', async () => {
+    const s = await store.create({ providerId: 'openai' });
+    expect(readdirSync(dir)).toContain(`${s.id}.json`);
+  });
+});
+
+describe('FileSessionStore.get', () => {
+  it('returns undefined for unknown id', async () => {
+    expect(await store.get('does-not-exist')).toBeUndefined();
+  });
+
+  it('round-trips a created session', async () => {
+    const s = await store.create({ providerId: 'openai' });
+    const got = await store.get(s.id);
+    expect(got).toEqual(s);
+  });
+});
+
+describe('FileSessionStore.list', () => {
+  it('returns empty array when dir does not exist', async () => {
+    const empty = new FileSessionStore(join(dir, 'missing'));
+    expect(await empty.list()).toEqual([]);
+  });
+
+  it('omits messages and sorts by updatedAt desc', async () => {
+    const a = await store.create({ providerId: 'openai', title: 'older' });
+    await new Promise((r) => setTimeout(r, 5));
+    const b = await store.create({ providerId: 'openai', title: 'newer' });
+    const list = await store.list();
+    expect(list.map((s) => s.id)).toEqual([b.id, a.id]);
+    expect((list[0] as Record<string, unknown>).messages).toBeUndefined();
+  });
+});
+
+describe('FileSessionStore.appendMessage', () => {
+  it('appends to messages and bumps updatedAt', async () => {
+    const s = await store.create({ providerId: 'openai' });
+    await new Promise((r) => setTimeout(r, 5));
+    const updated = await store.appendMessage(s.id, {
+      role: 'user',
+      content: 'hi',
+    });
+    expect(updated.messages).toHaveLength(1);
+    expect(updated.messages[0]).toEqual({ role: 'user', content: 'hi' });
+    expect(updated.updatedAt > s.updatedAt).toBe(true);
+  });
+
+  it('derives title from first user message when title is empty', async () => {
+    const s = await store.create({ providerId: 'openai' });
+    const updated = await store.appendMessage(s.id, {
+      role: 'user',
+      content: 'what is atlas?',
+    });
+    expect(updated.title).toBe('what is atlas?');
+  });
+
+  it('does not overwrite an existing title', async () => {
+    const s = await store.create({ providerId: 'openai', title: 'kept' });
+    const updated = await store.appendMessage(s.id, {
+      role: 'user',
+      content: 'something else',
+    });
+    expect(updated.title).toBe('kept');
+  });
+
+  it('throws when session is missing', async () => {
+    await expect(
+      store.appendMessage('nope', { role: 'user', content: 'x' }),
+    ).rejects.toThrow(/nope/);
+  });
+});
+
+describe('FileSessionStore.delete', () => {
+  it('removes the session', async () => {
+    const s = await store.create({ providerId: 'openai' });
+    await store.delete(s.id);
+    expect(await store.get(s.id)).toBeUndefined();
+  });
+
+  it('is a no-op for unknown id', async () => {
+    await store.delete('nope');
+  });
+});

--- a/apps/daemon/src/sessions/store.ts
+++ b/apps/daemon/src/sessions/store.ts
@@ -1,0 +1,109 @@
+import { mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export type SessionMessage = {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};
+
+export type Session = {
+  id: string;
+  title: string;
+  providerId: string;
+  model?: string;
+  createdAt: string;
+  updatedAt: string;
+  messages: SessionMessage[];
+};
+
+export type SessionSummary = Omit<Session, 'messages'>;
+
+export type CreateSessionInput = {
+  providerId: string;
+  model?: string;
+  title?: string;
+};
+
+const TITLE_MAX = 60;
+
+export class FileSessionStore {
+  constructor(private readonly dir: string) {}
+
+  async create(input: CreateSessionInput): Promise<Session> {
+    const now = new Date().toISOString();
+    const session: Session = {
+      id: crypto.randomUUID(),
+      title: input.title ?? '',
+      providerId: input.providerId,
+      model: input.model,
+      createdAt: now,
+      updatedAt: now,
+      messages: [],
+    };
+    await this.write(session);
+    return session;
+  }
+
+  async get(id: string): Promise<Session | undefined> {
+    try {
+      const raw = await readFile(this.fileFor(id), 'utf8');
+      return JSON.parse(raw) as Session;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw err;
+    }
+  }
+
+  async list(): Promise<SessionSummary[]> {
+    let entries: string[];
+    try {
+      entries = await readdir(this.dir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw err;
+    }
+    const summaries: SessionSummary[] = [];
+    for (const f of entries) {
+      if (!f.endsWith('.json')) continue;
+      const raw = await readFile(join(this.dir, f), 'utf8');
+      const s = JSON.parse(raw) as Session;
+      const { messages: _omit, ...summary } = s;
+      summaries.push(summary);
+    }
+    summaries.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+    return summaries;
+  }
+
+  async appendMessage(id: string, msg: SessionMessage): Promise<Session> {
+    const session = await this.get(id);
+    if (!session) throw new Error(`session not found: ${id}`);
+    session.messages.push(msg);
+    if (!session.title && msg.role === 'user') {
+      session.title = msg.content.slice(0, TITLE_MAX);
+    }
+    session.updatedAt = new Date().toISOString();
+    await this.write(session);
+    return session;
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      await unlink(this.fileFor(id));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw err;
+    }
+  }
+
+  private fileFor(id: string): string {
+    return join(this.dir, `${id}.json`);
+  }
+
+  private async write(session: Session): Promise<void> {
+    await mkdir(this.dir, { recursive: true });
+    const target = this.fileFor(session.id);
+    const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
+    await writeFile(tmp, JSON.stringify(session, null, 2));
+    await rename(tmp, target);
+  }
+}

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -118,18 +118,23 @@ flowchart TB
 | 桌面 | Electron（**当前阶段暂缓**） | 仅作为壳；与 daemon 通过 HTTP 通信；先把后端跑通再做 |
 | Agent Loop（native） | **Vercel AI SDK** | provider 抽象 + 流式 + tool calling + maxSteps 一站式；多家 LLM 不需要自己写 SSE 解析 |
 | Anthropic 订阅接入 | **Claude SDK passthrough** | 订阅 OAuth 凭据躺在本机 `claude` CLI 里，没有"裸调 LLM"接口可走；只能 spawn SDK 让它跑整轮 loop |
+| 应用数据目录 | **`~/.atlas/`**（可由 `ATLAS_HOME` 覆盖） | 单一 root 收纳配置 / 凭据 / 会话；环境变量覆盖便于测试隔离与多 profile |
+| 应用配置 | **`~/.atlas/config.json`** | 起步只放 daemon port、默认 provider/model、`sessions.dir`；hand-edit 即可 |
 | Provider 凭据存储 | **`~/.atlas/credentials.json` + 0600** | 早期单机单用户；不上 keychain（YAGNI），后续多端共享时再换 |
+| 会话持久化 | **per-session JSON 文件**（默认 `~/.atlas/sessions/<id>.json`） | 一会话一文件、原子 rename 写入；本地几百会话足够；`config.sessions.dir` 可改路径，未来要 PG 直接换 store 实现 |
 | 向量库 | 待定 | 实现 RAG 时再决（候选：LanceDB / Qdrant / pgvector） |
 
 ## 数据流：一次问答
 
-1. 客户端 `POST /chat` 携带 `providerId` + `messages`（+ 可选 `model`）
-2. Provider 层按 `providerId` 路由：要么走 native loop，要么委托给 Claude SDK passthrough
-3. Agent Loop 启动，初始消息进入推理
-4. LLM 决定调用 `retrieve` 工具 → RAG 模块查询向量库（必要时 rerank）
-5. 检索结果作为 tool result 回灌到对话
-6. （可选）LLM 调用 `web_search` 补充信息
-7. LLM 输出最终答复，通过 SSE 流式回客户端
+1. 客户端 `POST /chat` 携带 `message`（单条新 user 消息）+ 可选 `sessionId`；首轮无 `sessionId` 时必须给 `providerId`/`model`，daemon 会新建 session
+2. daemon 从 session store 读出历史 messages，把新 user 消息追加并落盘
+3. Provider 层按 session 的 `providerId` 路由：要么走 native loop，要么委托给 Claude SDK passthrough
+4. Agent Loop 启动，整段 messages 进入推理
+5. LLM 决定调用 `retrieve` 工具 → RAG 模块查询向量库（必要时 rerank）
+6. 检索结果作为 tool result 回灌到对话
+7. （可选）LLM 调用 `web_search` 补充信息
+8. LLM 输出最终答复，通过 SSE 流式回客户端；流结束后 daemon 把 assistant 文本追加进 session
+9. 响应头 `X-Atlas-Session-Id` 始终携带本轮 session id（新建/复用都给）
 
 ## 数据流：文档摄入
 
@@ -143,9 +148,9 @@ flowchart TB
 ## 待定项
 
 - 鉴权方案（本地无需，多端共用时怎么处理）
-- 会话与历史的持久化层（SQLite / Postgres）
 - 文档 ingest 的触发方式（CLI / UI 拖拽 / 文件夹 watcher）
 - 桌面端是否内嵌 daemon 进程，还是后台服务方式
 - 工具扩展机制（插件 / MCP / 内置）
+- 会话存储后端从 file 切到 PG / SQLite 的触发条件（当前 file 够用）
 
 > 待定项有结论时，更新本表并把决策迁到「关键决策」表。

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -25,15 +25,17 @@ atlas/
 │   │   ├── tsconfig.json
 │   │   └── src/
 │   │       ├── index.ts        # buildApp + createDefaultRegistry（不带 IO 副作用）
-│   │       ├── server.ts       # Bun.serve 启动入口
-│   │       ├── http/           # HTTP 路由：/chat、/providers、SSE 编码
+│   │       ├── server.ts       # Bun.serve 启动入口；解析 config 并装配 IO 依赖
+│   │       ├── config/         # ATLAS_HOME / config.json 解析；派生 sessions/credentials 路径
+│   │       ├── http/           # HTTP 路由：/chat、/providers、/sessions、SSE 编码
 │   │       ├── agent/          # native agent loop（Vercel AI SDK），非 Claude 路径用
 │   │       │   └── loop.ts
-│   │       └── providers/      # provider 抽象 + 凭据存储 + 各家 adapter
-│   │           ├── types.ts
-│   │           ├── registry.ts
-│   │           ├── credentials.ts
-│   │           └── adapters/   # 每家 provider 一个文件：claude-cli.ts / openai.ts / kimi.ts
+│   │       ├── providers/      # provider 抽象 + 凭据存储 + 各家 adapter
+│   │       │   ├── types.ts
+│   │       │   ├── registry.ts
+│   │       │   ├── credentials.ts
+│   │       │   └── adapters/   # 每家 provider 一个文件：claude-cli.ts / openai.ts / kimi.ts
+│   │       └── sessions/       # 会话存储；当前仅 FileSessionStore（一会话一 JSON）
 │   └── desktop/                # 桌面端（Electron + Vite + React）
 │       ├── electron.vite.config.ts
 │       ├── index.html
@@ -62,6 +64,16 @@ atlas/
 | `apps/desktop/` | Electron 桌面端；通过 `localhost:3001` 调 daemon |
 | `.claude/skills/` | Claude Code 项目级 skills；当前包含 `git-workflow`、`tdd` |
 | `docs/` | 项目文档；维护规则参考 `docs/CLAUDE.md` |
+
+## 应用数据目录（运行时，仓库外）
+
+| 路径 | 内容 |
+|------|------|
+| `~/.atlas/config.json` | 应用配置：daemon port、默认 provider/model、`sessions.dir` |
+| `~/.atlas/credentials.json` | provider 凭据（0600） |
+| `~/.atlas/sessions/<id>.json` | 会话历史（一会话一文件） |
+
+整个 root 可由 `ATLAS_HOME` 环境变量覆盖；`sessions.dir` 还可在 `config.json` 里单独指向别处。
 
 ## 后续会出现的目录
 


### PR DESCRIPTION
## Summary
让 daemon 拥有应用级配置（`config.json`）和会话持久化（per-session JSON）。
配置目录默认 `~/.atlas/`，可由 `ATLAS_HOME` 覆盖；会话目录可在 `config.json` 里再单独指向别处。
设计保持「够用即可」——只有一个 file 实现，没有抽 `SessionStore` 接口；等 PG 真的接进来时再换实现。

## Changes
- `apps/daemon/src/config/`：`ATLAS_HOME` 解析 + `config.json` 读取，派生 `sessions.dir` / `credentialsPath`，缺失字段用默认值
- `apps/daemon/src/sessions/`：`FileSessionStore` 一会话一文件、原子 rename；`list / get / create / appendMessage / delete`；首次 user 消息自动派生 title
- `apps/daemon/src/http/sessions.ts`：`GET / POST / DELETE /sessions`、`GET /sessions/:id`
- `apps/daemon/src/http/chat.ts`：请求体改为 `{ sessionId?, providerId?, model?, message }`；daemon 拼历史发给 provider，流结束回写 assistant 文本；响应头 `X-Atlas-Session-Id` 永远携带
- `apps/daemon/src/server.ts`：启动时 `loadConfig()` 装配 `CredentialStore` / `FileSessionStore`，端口走 `config.daemon.port`（仍允许 `PORT` env 覆盖）
- `docs/architecture/overview.md`：把会话持久化从「待定项」迁到「关键决策」；问答数据流补上 sessionId 流向
- `docs/project-structure.md`：新增 `config/` `sessions/` 目录说明 + 应用数据目录章节

## Test plan
- [x] `bun test`（72 passed）
- [x] `bun run check`（tsc 无错）
- [ ] `ATLAS_HOME=/tmp/atlas-smoke bun --cwd apps/daemon dev` 启动；`curl localhost:3001/sessions` 返回 `[]`；`POST /chat` 创建会话→响应头有 `X-Atlas-Session-Id`→`GET /sessions/:id` 看到完整 transcript
- [ ] 删 `~/.atlas/credentials.json` 后重启不崩；重新 login 仍 0600

## Out of scope（下一个 PR）
- 桌面端接入新的 `/chat` 形状 + 会话列表 UI
- PG 后端实现 / 跨会话「长期记忆」

## Related
Closes #14