### PR TITLE
feat(desktop): wire renderer to session-aware /chat with sidebar history

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { DaemonClient, type ChatMessage } from './client/daemon';
+import { DaemonClient } from './client/daemon';
 import { useAtlas } from './state/useAtlas';
 import { Sidebar } from './components/Sidebar';
 import { Chat } from './components/Chat';
@@ -27,12 +27,22 @@ export function App() {
     }
   }, [dispatch]);
 
+  const refreshSessions = useCallback(async () => {
+    try {
+      const sessions = await client.listSessions();
+      dispatch({ type: 'sessions/set', sessions });
+    } catch {
+      // daemon polling already surfaces unreachability; swallow here.
+    }
+  }, [dispatch]);
+
   // Initial fetch + poll lightly so reconnect is automatic.
   useEffect(() => {
     refreshProviders();
+    refreshSessions();
     const t = setInterval(refreshProviders, 10_000);
     return () => clearInterval(t);
-  }, [refreshProviders]);
+  }, [refreshProviders, refreshSessions]);
 
   const activeProvider = useMemo(
     () => state.providers.find((p) => p.id === state.activeProviderId),
@@ -45,7 +55,30 @@ export function App() {
       (p) => p.id === state.activeProviderId,
     );
     const next = state.providers[(idx + 1) % state.providers.length];
-    if (next) dispatch({ type: 'provider/activate', id: next.id });
+    if (!next) return;
+    // A session is sticky to its provider on the daemon side, so switching
+    // providers implicitly starts a new chat.
+    if (state.currentSessionId) dispatch({ type: 'session/new' });
+    dispatch({ type: 'provider/activate', id: next.id });
+  };
+
+  const selectSession = async (id: string) => {
+    try {
+      const session = await client.getSession(id);
+      if (session) dispatch({ type: 'session/load', session });
+    } catch {
+      // ignore — user can retry.
+    }
+  };
+
+  const deleteSession = async (id: string) => {
+    try {
+      await client.deleteSession(id);
+      if (state.currentSessionId === id) dispatch({ type: 'session/new' });
+      await refreshSessions();
+    } catch {
+      // ignore — user can retry.
+    }
   };
 
   const send = async (content: string) => {
@@ -54,17 +87,21 @@ export function App() {
     const assistantId = crypto.randomUUID();
     dispatch({ type: 'message/start-assistant', id: assistantId });
 
-    const history: ChatMessage[] = [
-      ...state.messages.map((m) => ({ role: m.role, content: m.content })),
-      { role: 'user', content },
-    ];
+    const wasNewSession = state.currentSessionId === null;
 
     try {
-      for await (const event of client.chat({
+      const { sessionId, events } = await client.chat({
+        sessionId: state.currentSessionId ?? undefined,
         providerId: activeProvider.id,
         model: DEFAULT_MODEL[activeProvider.id],
-        messages: history,
-      })) {
+        message: { role: 'user', content },
+      });
+
+      if (wasNewSession) {
+        dispatch({ type: 'session/set-current', id: sessionId });
+      }
+
+      for await (const event of events) {
         if (event.type === 'text-delta') {
           dispatch({
             type: 'message/append-delta',
@@ -87,6 +124,7 @@ export function App() {
       });
     } finally {
       dispatch({ type: 'message/finish-assistant', id: assistantId });
+      refreshSessions();
     }
   };
 
@@ -95,7 +133,11 @@ export function App() {
       <Sidebar
         providers={state.providers}
         activeProviderId={state.activeProviderId}
-        onNewChat={() => dispatch({ type: 'messages/clear' })}
+        sessions={state.sessions}
+        currentSessionId={state.currentSessionId}
+        onNewChat={() => dispatch({ type: 'session/new' })}
+        onSelectSession={selectSession}
+        onDeleteSession={deleteSession}
         onOpenSettings={() => dispatch({ type: 'settings/toggle', show: true })}
         onCycleProvider={cycleProvider}
       />

--- a/apps/desktop/src/renderer/client/daemon.test.ts
+++ b/apps/desktop/src/renderer/client/daemon.test.ts
@@ -1,5 +1,48 @@
-import { describe, it, expect } from 'bun:test';
-import { parseSseFrames } from './daemon';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  type Mock,
+  spyOn,
+} from 'bun:test';
+import { DaemonClient, parseSseFrames, type Session } from './daemon';
+
+let fetchSpy: Mock<typeof fetch>;
+
+beforeEach(() => {
+  fetchSpy = spyOn(globalThis, 'fetch') as unknown as Mock<typeof fetch>;
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+function sseResponse(frames: string[], sessionId: string): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const enc = new TextEncoder();
+      for (const f of frames) controller.enqueue(enc.encode(f));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'content-type': 'text/event-stream',
+      'x-atlas-session-id': sessionId,
+    },
+  });
+}
 
 describe('parseSseFrames', () => {
   it('parses a single complete event', () => {
@@ -45,5 +88,142 @@ describe('parseSseFrames', () => {
     );
     expect(out.events).toEqual([{ type: 'done' }]);
     expect(out.remaining).toBe('');
+  });
+});
+
+describe('DaemonClient.chat', () => {
+  it('returns sessionId from X-Atlas-Session-Id header and streams events', async () => {
+    fetchSpy.mockResolvedValue(
+      sseResponse(
+        [
+          'event: text-delta\ndata: {"text":"hi"}\n\n',
+          'event: done\ndata: {}\n\n',
+        ],
+        'sess-abc',
+      ),
+    );
+
+    const client = new DaemonClient('http://example');
+    const { sessionId, events } = await client.chat({
+      providerId: 'openai',
+      message: { role: 'user', content: 'hello' },
+    });
+    expect(sessionId).toBe('sess-abc');
+
+    const collected = [];
+    for await (const ev of events) collected.push(ev);
+    expect(collected).toEqual([
+      { type: 'text-delta', text: 'hi' },
+      { type: 'done' },
+    ]);
+  });
+
+  it('passes sessionId in body when reusing a session', async () => {
+    fetchSpy.mockResolvedValue(
+      sseResponse(['event: done\ndata: {}\n\n'], 'sess-1'),
+    );
+
+    const client = new DaemonClient('http://example');
+    await client.chat({
+      sessionId: 'sess-1',
+      message: { role: 'user', content: 'turn 2' },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({
+      sessionId: 'sess-1',
+      message: { role: 'user', content: 'turn 2' },
+    });
+  });
+
+  it('throws when daemon returns an error status', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ error: 'session not found' }, { status: 404 }),
+    );
+
+    const client = new DaemonClient('http://example');
+    await expect(
+      client.chat({
+        sessionId: 'nope',
+        message: { role: 'user', content: 'hi' },
+      }),
+    ).rejects.toThrow(/session not found/);
+  });
+
+  it('throws when X-Atlas-Session-Id header is missing', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.close();
+      },
+    });
+    fetchSpy.mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    const client = new DaemonClient('http://example');
+    await expect(
+      client.chat({ providerId: 'openai', message: { role: 'user', content: 'hi' } }),
+    ).rejects.toThrow(/X-Atlas-Session-Id/);
+  });
+});
+
+describe('DaemonClient.listSessions', () => {
+  it('returns the session summaries', async () => {
+    const summary = {
+      id: 's1',
+      title: 'first',
+      providerId: 'openai',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    fetchSpy.mockResolvedValue(jsonResponse([summary]));
+    const client = new DaemonClient('http://example');
+    expect(await client.listSessions()).toEqual([summary]);
+    expect(fetchSpy).toHaveBeenCalledWith('http://example/sessions');
+  });
+
+  it('throws on non-200', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({}, { status: 500 }));
+    const client = new DaemonClient('http://example');
+    await expect(client.listSessions()).rejects.toThrow();
+  });
+});
+
+describe('DaemonClient.getSession', () => {
+  it('returns the session', async () => {
+    const session: Session = {
+      id: 's1',
+      title: 't',
+      providerId: 'openai',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      messages: [{ role: 'user', content: 'hi' }],
+    };
+    fetchSpy.mockResolvedValue(jsonResponse(session));
+    const client = new DaemonClient('http://example');
+    expect(await client.getSession('s1')).toEqual(session);
+    expect(fetchSpy).toHaveBeenCalledWith('http://example/sessions/s1');
+  });
+
+  it('returns undefined on 404', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({}, { status: 404 }));
+    const client = new DaemonClient('http://example');
+    expect(await client.getSession('nope')).toBeUndefined();
+  });
+});
+
+describe('DaemonClient.deleteSession', () => {
+  it('sends DELETE', async () => {
+    fetchSpy.mockResolvedValue(new Response(null, { status: 204 }));
+    const client = new DaemonClient('http://example');
+    await client.deleteSession('s1');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://example/sessions/s1',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
   });
 });

--- a/apps/desktop/src/renderer/client/daemon.ts
+++ b/apps/desktop/src/renderer/client/daemon.ts
@@ -24,9 +24,33 @@ export type ProviderInfo = {
   status: { loggedIn: boolean; detail?: string };
 };
 
-export type ChatMessage = {
+export type SessionMessage = {
   role: 'user' | 'assistant' | 'system';
   content: string;
+};
+
+export type SessionSummary = {
+  id: string;
+  title: string;
+  providerId: string;
+  model?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type Session = SessionSummary & { messages: SessionMessage[] };
+
+export type ChatRequest = {
+  sessionId?: string;
+  providerId?: string;
+  model?: string;
+  message: { role: 'user'; content: string };
+  signal?: AbortSignal;
+};
+
+export type ChatResponse = {
+  sessionId: string;
+  events: AsyncIterable<AgentEvent>;
 };
 
 const DEFAULT_BASE_URL = 'http://localhost:3001';
@@ -62,49 +86,77 @@ export class DaemonClient {
     }
   }
 
-  async *chat(req: {
-    providerId: string;
-    model?: string;
-    messages: ChatMessage[];
-    signal?: AbortSignal;
-  }): AsyncIterable<AgentEvent> {
+  async listSessions(): Promise<SessionSummary[]> {
+    const res = await fetch(`${this.baseUrl}/sessions`);
+    if (!res.ok) throw new Error(`GET /sessions failed: ${res.status}`);
+    return (await res.json()) as SessionSummary[];
+  }
+
+  async getSession(id: string): Promise<Session | undefined> {
+    const res = await fetch(`${this.baseUrl}/sessions/${id}`);
+    if (res.status === 404) return undefined;
+    if (!res.ok) throw new Error(`GET /sessions/${id} failed: ${res.status}`);
+    return (await res.json()) as Session;
+  }
+
+  async deleteSession(id: string): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/sessions/${id}`, {
+      method: 'DELETE',
+    });
+    if (!res.ok && res.status !== 204) {
+      throw new Error(`DELETE /sessions/${id} failed: ${res.status}`);
+    }
+  }
+
+  async chat(req: ChatRequest): Promise<ChatResponse> {
+    const body: Record<string, unknown> = { message: req.message };
+    if (req.sessionId) body.sessionId = req.sessionId;
+    if (req.providerId) body.providerId = req.providerId;
+    if (req.model) body.model = req.model;
+
     const res = await fetch(`${this.baseUrl}/chat`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        providerId: req.providerId,
-        ...(req.model && { model: req.model }),
-        messages: req.messages,
-      }),
+      body: JSON.stringify(body),
       ...(req.signal && { signal: req.signal }),
     });
 
     if (!res.ok || !res.body) {
-      const body = (await res.json().catch(() => ({}))) as { error?: string };
-      yield { type: 'error', message: body.error ?? `chat failed: ${res.status}` };
-      return;
+      const errBody = (await res.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      throw new Error(errBody.error ?? `chat failed: ${res.status}`);
     }
 
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = '';
+    const sessionId = res.headers.get('x-atlas-session-id');
+    if (!sessionId) {
+      throw new Error('daemon did not return X-Atlas-Session-Id header');
+    }
 
-    try {
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const parsed = parseSseFrames(buffer);
-        buffer = parsed.remaining;
-        for (const event of parsed.events) yield event;
-      }
-      // Flush final decoder buffer + any remaining frame.
-      buffer += decoder.decode();
+    return { sessionId, events: streamEvents(res.body) };
+  }
+}
+
+async function* streamEvents(
+  body: ReadableStream<Uint8Array>,
+): AsyncIterable<AgentEvent> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
       const parsed = parseSseFrames(buffer);
+      buffer = parsed.remaining;
       for (const event of parsed.events) yield event;
-    } finally {
-      reader.releaseLock();
     }
+    buffer += decoder.decode();
+    const parsed = parseSseFrames(buffer);
+    for (const event of parsed.events) yield event;
+  } finally {
+    reader.releaseLock();
   }
 }
 
@@ -149,3 +201,4 @@ function parseFrame(frame: string): AgentEvent | null {
   }
   return { type: eventType, ...payload } as AgentEvent;
 }
+

--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -1,10 +1,14 @@
-import type { ProviderInfo } from '../client/daemon';
-import { GearIcon, PlusIcon } from './icons';
+import type { ProviderInfo, SessionSummary } from '../client/daemon';
+import { GearIcon, PlusIcon, TrashIcon } from './icons';
 
 type Props = {
   providers: ProviderInfo[];
   activeProviderId: string | null;
+  sessions: SessionSummary[];
+  currentSessionId: string | null;
   onNewChat(): void;
+  onSelectSession(id: string): void;
+  onDeleteSession(id: string): void;
   onOpenSettings(): void;
   onCycleProvider(): void;
 };
@@ -12,7 +16,11 @@ type Props = {
 export function Sidebar({
   providers,
   activeProviderId,
+  sessions,
+  currentSessionId,
   onNewChat,
+  onSelectSession,
+  onDeleteSession,
   onOpenSettings,
   onCycleProvider,
 }: Props) {
@@ -32,9 +40,19 @@ export function Sidebar({
 
       <div className="group-label">Conversations</div>
       <div className="convo-list">
-        <div className="empty-hint">
-          No saved chats yet — history will appear here once persistence lands.
-        </div>
+        {sessions.length === 0 ? (
+          <div className="empty-hint">No conversations yet.</div>
+        ) : (
+          sessions.map((s) => (
+            <SessionItem
+              key={s.id}
+              session={s}
+              active={s.id === currentSessionId}
+              onSelect={() => onSelectSession(s.id)}
+              onDelete={() => onDeleteSession(s.id)}
+            />
+          ))
+        )}
       </div>
 
       <div className="sidebar-foot">
@@ -52,5 +70,43 @@ export function Sidebar({
         </button>
       </div>
     </aside>
+  );
+}
+
+function SessionItem({
+  session,
+  active,
+  onSelect,
+  onDelete,
+}: {
+  session: SessionSummary;
+  active: boolean;
+  onSelect(): void;
+  onDelete(): void;
+}) {
+  const label = session.title.trim() || 'Untitled chat';
+  return (
+    <div className={`convo-item${active ? ' active' : ''}`}>
+      <button
+        type="button"
+        className="convo-label"
+        onClick={onSelect}
+        title={label}
+      >
+        {label}
+      </button>
+      <button
+        type="button"
+        className="convo-delete"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete();
+        }}
+        aria-label="Delete chat"
+        title="Delete chat"
+      >
+        <TrashIcon />
+      </button>
+    </div>
   );
 }

--- a/apps/desktop/src/renderer/components/icons.tsx
+++ b/apps/desktop/src/renderer/components/icons.tsx
@@ -38,6 +38,28 @@ export function GearIcon({ size = 14 }: IconProps) {
   );
 }
 
+export function TrashIcon({ size = 13 }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+      <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
+    </svg>
+  );
+}
+
 export function CloseIcon({ size = 14 }: IconProps) {
   return (
     <svg

--- a/apps/desktop/src/renderer/state/useAtlas.ts
+++ b/apps/desktop/src/renderer/state/useAtlas.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from 'react';
-import type { ProviderInfo } from '../client/daemon';
+import type { ProviderInfo, Session, SessionSummary } from '../client/daemon';
 
 export type ThemePref = 'light' | 'dark' | 'system';
 
@@ -13,6 +13,8 @@ export type AtlasState = {
   theme: ThemePref;
   providers: ProviderInfo[];
   activeProviderId: string | null;
+  sessions: SessionSummary[];
+  currentSessionId: string | null;
   messages: ChatTurn[];
   streaming: boolean;
   showSettings: boolean;
@@ -23,12 +25,15 @@ type Action =
   | { type: 'theme/set'; theme: ThemePref }
   | { type: 'providers/set'; providers: ProviderInfo[] }
   | { type: 'provider/activate'; id: string }
+  | { type: 'sessions/set'; sessions: SessionSummary[] }
+  | { type: 'session/set-current'; id: string | null }
+  | { type: 'session/load'; session: Session }
   | { type: 'settings/toggle'; show?: boolean }
   | { type: 'message/append-user'; content: string }
   | { type: 'message/start-assistant'; id: string }
   | { type: 'message/append-delta'; id: string; text: string }
   | { type: 'message/finish-assistant'; id: string }
-  | { type: 'messages/clear' }
+  | { type: 'session/new' }
   | { type: 'daemon/reachable'; reachable: boolean };
 
 function reducer(state: AtlasState, action: Action): AtlasState {
@@ -47,6 +52,22 @@ function reducer(state: AtlasState, action: Action): AtlasState {
     }
     case 'provider/activate':
       return { ...state, activeProviderId: action.id };
+    case 'sessions/set':
+      return { ...state, sessions: action.sessions };
+    case 'session/set-current':
+      return { ...state, currentSessionId: action.id };
+    case 'session/load':
+      return {
+        ...state,
+        currentSessionId: action.session.id,
+        activeProviderId: action.session.providerId,
+        messages: action.session.messages
+          .filter((m): m is { role: 'user' | 'assistant'; content: string } =>
+            m.role === 'user' || m.role === 'assistant',
+          )
+          .map((m) => ({ id: crypto.randomUUID(), ...m })),
+        streaming: false,
+      };
     case 'settings/toggle':
       return {
         ...state,
@@ -78,8 +99,13 @@ function reducer(state: AtlasState, action: Action): AtlasState {
       };
     case 'message/finish-assistant':
       return { ...state, streaming: false };
-    case 'messages/clear':
-      return { ...state, messages: [], streaming: false };
+    case 'session/new':
+      return {
+        ...state,
+        currentSessionId: null,
+        messages: [],
+        streaming: false,
+      };
     case 'daemon/reachable':
       return { ...state, daemonReachable: action.reachable };
     default:
@@ -110,6 +136,8 @@ export function useAtlas() {
     theme: readStoredTheme(),
     providers: [],
     activeProviderId: null,
+    sessions: [],
+    currentSessionId: null,
     messages: [],
     streaming: false,
     showSettings: false,

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -212,19 +212,46 @@ button { font: inherit; }
   padding: 0 4px;
 }
 
-.convo {
-  padding: 6px 12px;
-  font-size: 13px;
-  color: var(--text-mute);
-  cursor: pointer;
+.convo-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   border-radius: 8px;
+  margin-bottom: 1px;
+  color: var(--text-mute);
+}
+.convo-item:hover { background: var(--side-hover); color: var(--text); }
+.convo-item.active { background: var(--side-active); color: var(--text); }
+
+.convo-label {
+  flex: 1;
+  text-align: left;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 6px 0 6px 12px;
+  font-size: 13px;
+  color: inherit;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 1px;
+  font-family: inherit;
 }
-.convo:hover { background: var(--side-hover); color: var(--text); }
-.convo.active { background: var(--side-active); color: var(--text); }
+
+.convo-delete {
+  flex: none;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 6px;
+  color: var(--text-faint);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.convo-item:hover .convo-delete,
+.convo-item.active .convo-delete { opacity: 1; }
+.convo-delete:hover { background: var(--card-hover); color: var(--danger, #d93b3b); }
 
 .empty-hint {
   padding: 10px 14px;


### PR DESCRIPTION
## Summary
接上 PR #15。把桌面端从「客户端持有整段 transcript」改为「daemon 拥有会话，客户端只发增量 user 消息」。
侧栏占位的"history will appear here"换成真正的会话列表，切换 / 删除走 `/sessions`。

## Changes
- `client/daemon.ts`：`chat()` → `Promise<{ sessionId, events }>`，从 `X-Atlas-Session-Id` 取 session id；新增 `listSessions` / `getSession` / `deleteSession`
- `state/useAtlas.ts`：`currentSessionId` + `sessions[]` + 三个新 action（`sessions/set` / `session/set-current` / `session/load` / `session/new`）；`session/load` 把存档的 messages 转回 UI 的 `ChatTurn`
- `App.tsx`：`send()` 用新形状，首轮回填 sessionId，流结束刷新 sessions；mount 时拉一次会话列表；切 provider 在已有会话上自动开新聊天（session 的 providerId 在 daemon 端是 sticky 的）
- `components/Sidebar.tsx`：会话列表渲染 + active 高亮 + hover 显示删除按钮
- `components/icons.tsx`：新增 `TrashIcon`
- `styles.css`：把没人用的 `.convo` 占位换成 `.convo-item / -label / -delete`

## Test plan
- [x] `bun test`（14 passed）
- [x] `bun run check`（tsc 无错）
- [x] daemon smoke：\`ATLAS_HOME=/tmp/atlas-smoke PORT=3019 bun --cwd apps/daemon start\` → \`curl localhost:3019/sessions\` 返回 \`[]\`，\`/health\` 200
- [ ] 端到端：\`ATLAS_HOME=/tmp/atlas-smoke bun --cwd apps/daemon dev\` + \`bun --cwd apps/desktop dev\`，发消息能流式输出，侧栏出现新会话；重启 electron 后会话仍在；点会话能恢复 transcript；trash 删除生效
- [ ] 切 provider：在已有会话上点 provider pill → messages 清空、currentSessionId 重置（开新会话）

## Related
Closes #16