### PR TITLE
feat(daemon): add roles config and LLM-generated session titles

### DIFF
--- a/apps/daemon/src/config/config.test.ts
+++ b/apps/daemon/src/config/config.test.ts
@@ -36,6 +36,25 @@ describe('loadConfig', () => {
     expect(cfg.defaults).toEqual({});
     expect(cfg.sessions.dir).toBe(join(home, 'sessions'));
     expect(cfg.credentialsPath).toBe(join(home, 'credentials.json'));
+    expect(cfg.roles).toEqual({});
+  });
+
+  it('reads role overrides from config.json', async () => {
+    writeFileSync(
+      join(home, 'config.json'),
+      JSON.stringify({
+        roles: {
+          title: { model: 'k2-fast' },
+          compaction: { providerId: 'openai', model: 'gpt-4o-mini' },
+        },
+      }),
+    );
+    const cfg = await loadConfig(home);
+    expect(cfg.roles.title).toEqual({ model: 'k2-fast' });
+    expect(cfg.roles.compaction).toEqual({
+      providerId: 'openai',
+      model: 'gpt-4o-mini',
+    });
   });
 
   it('reads daemon.port from config.json', async () => {

--- a/apps/daemon/src/config/index.ts
+++ b/apps/daemon/src/config/index.ts
@@ -1,13 +1,15 @@
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
+import type { RoleConfig } from '../roles/resolver';
 
 export type AppConfig = {
   home: string;
   daemon: { port: number };
-  defaults: { providerId?: string; model?: string };
+  defaults: RoleConfig;
   sessions: { dir: string };
   credentialsPath: string;
+  roles: Record<string, RoleConfig>;
 };
 
 const DEFAULT_PORT = 3001;
@@ -54,11 +56,13 @@ export async function loadConfig(home?: string): Promise<AppConfig> {
     },
     sessions: { dir: sessionsDir },
     credentialsPath: join(root, 'credentials.json'),
+    roles: parsed.roles ?? {},
   };
 }
 
 type RawConfig = {
   daemon?: { port?: number };
-  defaults?: { providerId?: string; model?: string };
+  defaults?: RoleConfig;
   sessions?: { dir?: string };
+  roles?: Record<string, RoleConfig>;
 };

--- a/apps/daemon/src/http/chat.test.ts
+++ b/apps/daemon/src/http/chat.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { buildApp } from '../index';
 import type { Provider, ChatRequest, AgentEvent } from '../providers/types';
 import { ProviderRegistry } from '../providers/registry';
+import { RoleResolver } from '../roles/resolver';
 import { FileSessionStore } from '../sessions/store';
 
 const FIXED_REPLY = 'hello world';
@@ -40,7 +41,11 @@ beforeEach(() => {
   registry = new ProviderRegistry();
   calls = [];
   registry.register(fakeProvider(calls));
-  app = buildApp({ registry, sessions: store });
+  app = buildApp({
+    registry,
+    sessions: store,
+    roles: new RoleResolver({}, {}),
+  });
 });
 
 afterEach(() => {
@@ -173,5 +178,72 @@ describe('POST /chat', () => {
       headers: { 'content-type': 'application/json' },
     });
     expect(res.status).toBe(400);
+  });
+
+  it('generates a title via the title role after the first exchange', async () => {
+    const titleRegistry = new ProviderRegistry();
+    titleRegistry.register(fakeProvider());
+    titleRegistry.register({
+      id: 'openai',
+      displayName: 'openai (fake title)',
+      authMode: 'apiKey',
+      status: async () => ({ loggedIn: true }),
+      chat: function (): AsyncIterable<AgentEvent> {
+        return (async function* () {
+          yield { type: 'text-delta', text: 'Generated Title' };
+          yield { type: 'done' };
+        })();
+      },
+    });
+    const titleResolver = new RoleResolver(
+      { providerId: 'anthropic-claude-cli' },
+      { title: { providerId: 'openai' } },
+    );
+    const titleApp = buildApp({
+      registry: titleRegistry,
+      sessions: store,
+      roles: titleResolver,
+    });
+
+    const res = await titleApp.request('/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerId: 'anthropic-claude-cli',
+        message: { role: 'user', content: 'hi' },
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    const sid = res.headers.get('x-atlas-session-id');
+    await res.text();
+    expect(sid).toBeTruthy();
+
+    // Title generation is fire-and-forget — poll briefly until it lands.
+    const deadline = Date.now() + 500;
+    let title = '';
+    while (Date.now() < deadline) {
+      const s = await store.get(sid!);
+      if (s && s.title === 'Generated Title') {
+        title = s.title;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(title).toBe('Generated Title');
+  });
+
+  it('skips title generation when title role is unconfigured', async () => {
+    const res = await app.request('/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerId: 'anthropic-claude-cli',
+        message: { role: 'user', content: 'leave the title alone' },
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    const sid = res.headers.get('x-atlas-session-id');
+    await res.text();
+    await new Promise((r) => setTimeout(r, 50));
+    const s = await store.get(sid!);
+    expect(s?.title).toBe('leave the title alone');
   });
 });

--- a/apps/daemon/src/http/chat.ts
+++ b/apps/daemon/src/http/chat.ts
@@ -2,7 +2,9 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import type { ProviderRegistry } from '../providers/registry';
 import type { AgentEvent, ProviderId } from '../providers/types';
+import type { RoleResolver } from '../roles/resolver';
 import type { FileSessionStore, Session } from '../sessions/store';
+import { generateTitle } from '../tasks/title';
 import { sseStream } from './sse';
 
 const chatRequestSchema = z.object({
@@ -18,6 +20,7 @@ const chatRequestSchema = z.object({
 export function chatRouter(
   registry: ProviderRegistry,
   store: FileSessionStore,
+  roles: RoleResolver,
 ): Hono {
   const app = new Hono();
 
@@ -69,7 +72,11 @@ export function chatRouter(
     const sessionId = session.id;
     const persisted = persistAssistant(events, async (text) => {
       if (text.length === 0) return;
-      await store.appendMessage(sessionId, { role: 'assistant', content: text });
+      const updated = await store.appendMessage(sessionId, {
+        role: 'assistant',
+        content: text,
+      });
+      maybeGenerateTitle(updated, registry, roles, store);
     });
 
     return new Response(sseStream(persisted), {
@@ -102,4 +109,34 @@ async function* persistAssistant(
       console.error('failed to persist assistant message:', err);
     }
   }
+}
+
+function maybeGenerateTitle(
+  session: Session,
+  registry: ProviderRegistry,
+  roles: RoleResolver,
+  store: FileSessionStore,
+): void {
+  const [first, second] = session.messages;
+  if (
+    session.messages.length !== 2 ||
+    first?.role !== 'user' ||
+    second?.role !== 'assistant'
+  ) {
+    return;
+  }
+  if (!roles.resolve('title').providerId) return;
+
+  void generateTitle({
+    registry,
+    resolver: roles,
+    query: first.content,
+    reply: second.content,
+  })
+    .then((title) => {
+      if (title.length > 0) return store.setTitle(session.id, title);
+    })
+    .catch((err) => {
+      console.error('title generation failed:', err);
+    });
 }

--- a/apps/daemon/src/http/providers.test.ts
+++ b/apps/daemon/src/http/providers.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { buildApp } from '../index';
 import type { Provider } from '../providers/types';
 import { ProviderRegistry } from '../providers/registry';
+import { RoleResolver } from '../roles/resolver';
 import { FileSessionStore } from '../sessions/store';
 
 let sessionsDir: string;
@@ -33,7 +34,11 @@ function fakeProvider(overrides: Partial<Provider> = {}): Provider {
 function appWith(p: Provider): ReturnType<typeof buildApp> {
   const registry = new ProviderRegistry();
   registry.register(p);
-  return buildApp({ registry, sessions: new FileSessionStore(sessionsDir) });
+  return buildApp({
+    registry,
+    sessions: new FileSessionStore(sessionsDir),
+    roles: new RoleResolver({}, {}),
+  });
 }
 
 describe('GET /providers', () => {

--- a/apps/daemon/src/http/sessions.test.ts
+++ b/apps/daemon/src/http/sessions.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildApp } from '../index';
 import { ProviderRegistry } from '../providers/registry';
+import { RoleResolver } from '../roles/resolver';
 import { FileSessionStore, type Session, type SessionSummary } from '../sessions/store';
 
 let dir: string;
@@ -13,7 +14,11 @@ let app: ReturnType<typeof buildApp>;
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'atlas-sessions-http-'));
   store = new FileSessionStore(dir);
-  app = buildApp({ registry: new ProviderRegistry(), sessions: store });
+  app = buildApp({
+    registry: new ProviderRegistry(),
+    sessions: store,
+    roles: new RoleResolver({}, {}),
+  });
 });
 
 afterEach(() => {

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -5,6 +5,7 @@ import { claudeCliProvider } from './providers/adapters/claude-cli';
 import { openaiProvider } from './providers/adapters/openai';
 import { kimiProvider } from './providers/adapters/kimi';
 import { CredentialStore } from './providers/credentials';
+import { RoleResolver } from './roles/resolver';
 import { FileSessionStore } from './sessions/store';
 import { providersRouter } from './http/providers';
 import { chatRouter } from './http/chat';
@@ -13,10 +14,11 @@ import { sessionsRouter } from './http/sessions';
 export type BuildAppOptions = {
   registry: ProviderRegistry;
   sessions: FileSessionStore;
+  roles: RoleResolver;
 };
 
 export function buildApp(opts: BuildAppOptions): Hono {
-  const { registry, sessions } = opts;
+  const { registry, sessions, roles } = opts;
   const app = new Hono();
   app.use(
     '*',
@@ -28,7 +30,7 @@ export function buildApp(opts: BuildAppOptions): Hono {
   );
   app.get('/health', (c) => c.json({ status: 'ok' }));
   app.route('/providers', providersRouter(registry));
-  app.route('/chat', chatRouter(registry, sessions));
+  app.route('/chat', chatRouter(registry, sessions, roles));
   app.route('/sessions', sessionsRouter(sessions));
   return app;
 }

--- a/apps/daemon/src/roles/resolver.test.ts
+++ b/apps/daemon/src/roles/resolver.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'bun:test';
+import { RoleResolver } from './resolver';
+
+describe('RoleResolver.resolve', () => {
+  it('returns empty when nothing is configured', () => {
+    const r = new RoleResolver({}, {});
+    expect(r.resolve('title')).toEqual({});
+  });
+
+  it('falls back to defaults when role is unset', () => {
+    const r = new RoleResolver({ providerId: 'kimi', model: 'k2' }, {});
+    expect(r.resolve('title')).toEqual({ providerId: 'kimi', model: 'k2' });
+  });
+
+  it('lets role override individual fields, falling back to defaults for the rest', () => {
+    const r = new RoleResolver(
+      { providerId: 'kimi', model: 'k2' },
+      { title: { model: 'k2-fast' } },
+    );
+    expect(r.resolve('title')).toEqual({ providerId: 'kimi', model: 'k2-fast' });
+  });
+
+  it('lets role override providerId fully', () => {
+    const r = new RoleResolver(
+      { providerId: 'kimi', model: 'k2' },
+      { compaction: { providerId: 'openai', model: 'gpt-4o-mini' } },
+    );
+    expect(r.resolve('compaction')).toEqual({
+      providerId: 'openai',
+      model: 'gpt-4o-mini',
+    });
+  });
+
+  it('treats unknown role names as falling back to defaults', () => {
+    const r = new RoleResolver({ providerId: 'kimi' }, {});
+    expect(r.resolve('does-not-exist')).toEqual({ providerId: 'kimi' });
+  });
+});

--- a/apps/daemon/src/roles/resolver.ts
+++ b/apps/daemon/src/roles/resolver.ts
@@ -1,0 +1,21 @@
+export type RoleConfig = {
+  providerId?: string;
+  model?: string;
+};
+
+export class RoleResolver {
+  constructor(
+    private readonly defaults: RoleConfig,
+    private readonly roles: Record<string, RoleConfig>,
+  ) {}
+
+  resolve(name: string): RoleConfig {
+    const role = this.roles[name] ?? {};
+    const out: RoleConfig = {};
+    const providerId = role.providerId ?? this.defaults.providerId;
+    const model = role.model ?? this.defaults.model;
+    if (providerId !== undefined) out.providerId = providerId;
+    if (model !== undefined) out.model = model;
+    return out;
+  }
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1,13 +1,15 @@
 import { loadConfig } from './config';
 import { buildApp, createDefaultRegistry } from './index';
 import { CredentialStore } from './providers/credentials';
+import { RoleResolver } from './roles/resolver';
 import { FileSessionStore } from './sessions/store';
 
 const config = await loadConfig();
 const credentials = new CredentialStore(config.credentialsPath);
 const sessions = new FileSessionStore(config.sessions.dir);
 const registry = createDefaultRegistry(credentials);
-const app = buildApp({ registry, sessions });
+const roles = new RoleResolver(config.defaults, config.roles);
+const app = buildApp({ registry, sessions, roles });
 
 const port = Number(process.env.PORT ?? config.daemon.port);
 console.log(`atlas daemon listening on :${port} (home: ${config.home})`);

--- a/apps/daemon/src/sessions/store.test.ts
+++ b/apps/daemon/src/sessions/store.test.ts
@@ -108,6 +108,21 @@ describe('FileSessionStore.appendMessage', () => {
   });
 });
 
+describe('FileSessionStore.setTitle', () => {
+  it('overwrites the title and bumps updatedAt', async () => {
+    const s = await store.create({ providerId: 'openai', title: 'old' });
+    await new Promise((r) => setTimeout(r, 5));
+    await store.setTitle(s.id, 'new title');
+    const got = await store.get(s.id);
+    expect(got?.title).toBe('new title');
+    expect((got?.updatedAt ?? '') > s.updatedAt).toBe(true);
+  });
+
+  it('is a no-op for unknown id', async () => {
+    await store.setTitle('nope', 'hello');
+  });
+});
+
 describe('FileSessionStore.delete', () => {
   it('removes the session', async () => {
     const s = await store.create({ providerId: 'openai' });

--- a/apps/daemon/src/sessions/store.ts
+++ b/apps/daemon/src/sessions/store.ts
@@ -86,6 +86,14 @@ export class FileSessionStore {
     return session;
   }
 
+  async setTitle(id: string, title: string): Promise<void> {
+    const session = await this.get(id);
+    if (!session) return;
+    session.title = title;
+    session.updatedAt = new Date().toISOString();
+    await this.write(session);
+  }
+
   async delete(id: string): Promise<void> {
     try {
       await unlink(this.fileFor(id));

--- a/apps/daemon/src/tasks/runOneShot.test.ts
+++ b/apps/daemon/src/tasks/runOneShot.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'bun:test';
+import { ProviderRegistry } from '../providers/registry';
+import type { Provider, ChatRequest, AgentEvent } from '../providers/types';
+import { RoleResolver } from '../roles/resolver';
+import { runOneShot } from './runOneShot';
+
+function makeProvider(
+  id: string,
+  output: AgentEvent[],
+): Provider {
+  return {
+    id: id as Provider['id'],
+    displayName: id,
+    authMode: 'apiKey',
+    status: async () => ({ loggedIn: true }),
+    chat: function (_req: ChatRequest): AsyncIterable<AgentEvent> {
+      return (async function* () {
+        for (const ev of output) yield ev;
+      })();
+    },
+  };
+}
+
+function makeRegistry(...providers: Provider[]): ProviderRegistry {
+  const r = new ProviderRegistry();
+  for (const p of providers) r.register(p);
+  return r;
+}
+
+describe('runOneShot', () => {
+  it('joins text-delta events into a trimmed string', async () => {
+    const registry = makeRegistry(
+      makeProvider('openai', [
+        { type: 'text-delta', text: '  Hello ' },
+        { type: 'text-delta', text: 'world  ' },
+        { type: 'done' },
+      ]),
+    );
+    const resolver = new RoleResolver({ providerId: 'openai' }, {});
+    const out = await runOneShot({
+      registry,
+      resolver,
+      role: 'title',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(out).toBe('Hello world');
+  });
+
+  it('throws when role has no providerId configured', async () => {
+    const registry = makeRegistry();
+    const resolver = new RoleResolver({}, {});
+    await expect(
+      runOneShot({
+        registry,
+        resolver,
+        role: 'title',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    ).rejects.toThrow(/title/);
+  });
+
+  it('throws when provider is not registered', async () => {
+    const registry = makeRegistry();
+    const resolver = new RoleResolver({ providerId: 'ghost' }, {});
+    await expect(
+      runOneShot({
+        registry,
+        resolver,
+        role: 'title',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    ).rejects.toThrow(/ghost/);
+  });
+
+  it('passes the resolved model to the provider', async () => {
+    let capturedModel: string | undefined;
+    const provider: Provider = {
+      id: 'openai',
+      displayName: 'openai',
+      authMode: 'apiKey',
+      status: async () => ({ loggedIn: true }),
+      chat: function (req: ChatRequest): AsyncIterable<AgentEvent> {
+        capturedModel = req.model;
+        return (async function* () {
+          yield { type: 'text-delta', text: 'ok' };
+          yield { type: 'done' };
+        })();
+      },
+    };
+    const registry = makeRegistry(provider);
+    const resolver = new RoleResolver(
+      { providerId: 'openai', model: 'gpt-4o-mini' },
+      { title: { model: 'gpt-4o-nano' } },
+    );
+    await runOneShot({
+      registry,
+      resolver,
+      role: 'title',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(capturedModel).toBe('gpt-4o-nano');
+  });
+
+  it('throws when provider yields an error event', async () => {
+    const registry = makeRegistry(
+      makeProvider('openai', [
+        { type: 'error', message: 'rate limit' },
+      ]),
+    );
+    const resolver = new RoleResolver({ providerId: 'openai' }, {});
+    await expect(
+      runOneShot({
+        registry,
+        resolver,
+        role: 'title',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    ).rejects.toThrow(/rate limit/);
+  });
+});

--- a/apps/daemon/src/tasks/runOneShot.ts
+++ b/apps/daemon/src/tasks/runOneShot.ts
@@ -1,0 +1,34 @@
+import type { ProviderRegistry } from '../providers/registry';
+import type { ChatMessage, ProviderId } from '../providers/types';
+import type { RoleResolver } from '../roles/resolver';
+
+export type RunOneShotInput = {
+  registry: ProviderRegistry;
+  resolver: RoleResolver;
+  role: string;
+  messages: ChatMessage[];
+  signal?: AbortSignal;
+};
+
+export async function runOneShot(input: RunOneShotInput): Promise<string> {
+  const { providerId, model } = input.resolver.resolve(input.role);
+  if (!providerId) {
+    throw new Error(`role '${input.role}' has no providerId configured`);
+  }
+  const provider = input.registry.get(providerId);
+  if (!provider) {
+    throw new Error(`provider '${providerId}' is not registered`);
+  }
+
+  let buf = '';
+  for await (const ev of provider.chat({
+    providerId: provider.id as ProviderId,
+    model,
+    messages: input.messages,
+    signal: input.signal,
+  })) {
+    if (ev.type === 'text-delta') buf += ev.text;
+    else if (ev.type === 'error') throw new Error(ev.message);
+  }
+  return buf.trim();
+}

--- a/apps/daemon/src/tasks/title.test.ts
+++ b/apps/daemon/src/tasks/title.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'bun:test';
+import { ProviderRegistry } from '../providers/registry';
+import type { Provider, ChatRequest, AgentEvent } from '../providers/types';
+import { RoleResolver } from '../roles/resolver';
+import { generateTitle } from './title';
+
+function makeProvider(reply: string): Provider {
+  return {
+    id: 'openai',
+    displayName: 'openai',
+    authMode: 'apiKey',
+    status: async () => ({ loggedIn: true }),
+    chat: function (_req: ChatRequest): AsyncIterable<AgentEvent> {
+      return (async function* () {
+        yield { type: 'text-delta', text: reply };
+        yield { type: 'done' };
+      })();
+    },
+  };
+}
+
+function harness(reply: string) {
+  const r = new ProviderRegistry();
+  r.register(makeProvider(reply));
+  return {
+    registry: r,
+    resolver: new RoleResolver({ providerId: 'openai' }, {}),
+  };
+}
+
+describe('generateTitle', () => {
+  it('returns the model output trimmed', async () => {
+    const h = harness('  Atlas Onboarding Walkthrough  ');
+    expect(
+      await generateTitle({ ...h, query: 'how do I start?', reply: 'do X' }),
+    ).toBe('Atlas Onboarding Walkthrough');
+  });
+
+  it('strips wrapping quotes and trailing punctuation', async () => {
+    const h = harness('"Setup walkthrough."');
+    expect(
+      await generateTitle({ ...h, query: 'q', reply: 'r' }),
+    ).toBe('Setup walkthrough');
+  });
+
+  it('caps the title length', async () => {
+    const long = 'a'.repeat(200);
+    const h = harness(long);
+    const out = await generateTitle({ ...h, query: 'q', reply: 'r' });
+    expect(out.length).toBeLessThanOrEqual(60);
+  });
+});

--- a/apps/daemon/src/tasks/title.ts
+++ b/apps/daemon/src/tasks/title.ts
@@ -1,0 +1,40 @@
+import type { ProviderRegistry } from '../providers/registry';
+import type { RoleResolver } from '../roles/resolver';
+import { runOneShot } from './runOneShot';
+
+const MAX_TITLE_LEN = 60;
+const SYSTEM_PROMPT =
+  'You generate short conversation titles. Output 3 to 6 words that summarize the topic. No quotes, no surrounding punctuation, no trailing period.';
+const FOLLOW_UP =
+  'Now give me a 3-6 word title for this conversation. Output only the title.';
+
+export type GenerateTitleInput = {
+  registry: ProviderRegistry;
+  resolver: RoleResolver;
+  query: string;
+  reply: string;
+  signal?: AbortSignal;
+};
+
+export async function generateTitle(input: GenerateTitleInput): Promise<string> {
+  const text = await runOneShot({
+    registry: input.registry,
+    resolver: input.resolver,
+    role: 'title',
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: input.query.slice(0, 500) },
+      { role: 'assistant', content: input.reply.slice(0, 500) },
+      { role: 'user', content: FOLLOW_UP },
+    ],
+    signal: input.signal,
+  });
+  return sanitize(text);
+}
+
+function sanitize(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^["'`*\s]+|["'`*.!?\s]+$/g, '')
+    .slice(0, MAX_TITLE_LEN);
+}

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -102,6 +102,19 @@ flowchart TB
 
 不写统一的 loop 抽象去包两条路径——SDK 不暴露裸调 LLM 接口，强抽象只会做出个错位的中间层。
 
+## 多 agent 与一次性任务
+
+未来会出现多个角色（plan / build / title / summary / compaction），但它们不是同一种东西，分两层：
+
+| 层 | 角色 | 特性 |
+|----|------|------|
+| **agents/**（loop） | plan、build | 多步推理、可调工具、产出 SSE 事件 |
+| **tasks/**（one-shot） | title、summary、compaction | 单次 LLM 调用、输入→字符串/对象、无 tool registry |
+
+两层共用底层 provider，但接口形状不同。**所有调用都通过 `RoleResolver.resolve(name)` 拿 `{ providerId, model }`**，调用方不直接读 config。这让"给 title 单独配个便宜模型"成为一行 config 改动。
+
+当前已落地：`title`（首轮 user+assistant 后异步生成会话标题）。
+
 ## 关键决策
 
 | 决策 | 选择 | 理由 |
@@ -119,7 +132,8 @@ flowchart TB
 | Agent Loop（native） | **Vercel AI SDK** | provider 抽象 + 流式 + tool calling + maxSteps 一站式；多家 LLM 不需要自己写 SSE 解析 |
 | Anthropic 订阅接入 | **Claude SDK passthrough** | 订阅 OAuth 凭据躺在本机 `claude` CLI 里，没有"裸调 LLM"接口可走；只能 spawn SDK 让它跑整轮 loop |
 | 应用数据目录 | **`~/.atlas/`**（可由 `ATLAS_HOME` 覆盖） | 单一 root 收纳配置 / 凭据 / 会话；环境变量覆盖便于测试隔离与多 profile |
-| 应用配置 | **`~/.atlas/config.json`** | 起步只放 daemon port、默认 provider/model、`sessions.dir`；hand-edit 即可 |
+| 应用配置 | **`~/.atlas/config.json`** | 起步放 daemon port、`defaults` provider/model、`sessions.dir`、`roles` 表；hand-edit 即可 |
+| 多 agent 路由 | **role-based 配置** | `defaults` 给底，`roles.<name>` 单条覆盖 providerId/model；调用方走 `RoleResolver.resolve(name)`，不直接拼 providerId |
 | Provider 凭据存储 | **`~/.atlas/credentials.json` + 0600** | 早期单机单用户；不上 keychain（YAGNI），后续多端共享时再换 |
 | 会话持久化 | **per-session JSON 文件**（默认 `~/.atlas/sessions/<id>.json`） | 一会话一文件、原子 rename 写入；本地几百会话足够；`config.sessions.dir` 可改路径，未来要 PG 直接换 store 实现 |
 | 向量库 | 待定 | 实现 RAG 时再决（候选：LanceDB / Qdrant / pgvector） |

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -35,6 +35,8 @@ atlas/
 │   │       │   ├── registry.ts
 │   │       │   ├── credentials.ts
 │   │       │   └── adapters/   # 每家 provider 一个文件：claude-cli.ts / openai.ts / kimi.ts
+│   │       ├── roles/          # 多 agent 角色解析（defaults + role 覆盖）
+│   │       ├── tasks/          # 单次 LLM 调用任务（title 等）：runOneShot 助手 + 各任务实现
 │   │       └── sessions/       # 会话存储；当前仅 FileSessionStore（一会话一 JSON）
 │   └── desktop/                # 桌面端（Electron + Vite + React）
 │       ├── electron.vite.config.ts


### PR DESCRIPTION
## Summary
为多 agent 架构铺第一块砖：引入 \`RoleResolver\`，让"哪个角色用哪个 provider+model"成为一行 \`config.json\` 改动。
落地的第一个消费者是 **title 任务**——首轮 user+assistant 完成后异步生成会话标题，替换现有的截断占位。

## Changes
- \`apps/daemon/src/roles/resolver.ts\`：\`RoleResolver(defaults, roles)\`，role 缺字段回落 defaults
- \`apps/daemon/src/config/index.ts\`：\`AppConfig.roles: Record<string, RoleConfig>\`；沿用现有 \`defaults\` 字段（不引入第二份默认值）
- \`apps/daemon/src/tasks/runOneShot.ts\`：单次 LLM 调用助手，所有 one-shot 任务复用
- \`apps/daemon/src/tasks/title.ts\`：\`generateTitle({ query, reply })\` 用 title role 调一次，sanitize 后返回 3-6 词标题
- \`apps/daemon/src/sessions/store.ts\`：\`FileSessionStore.setTitle\` 提供回写通道
- \`apps/daemon/src/http/chat.ts\`：首轮 assistant 落盘后 fire-and-forget 触发 title；title role 未配置时直接跳过
- \`buildApp\` / \`server.ts\`：装配 \`RoleResolver\`
- 文档：\`overview.md\` 加多 agent 简介；\`project-structure.md\` 列 \`roles/\` \`tasks/\`

## Test plan
- [x] \`bun test\`（90 passed）
- [x] \`bun run check\`（tsc 干净）
- [ ] 手动：\`config.json\` 加 \`{ "defaults": { "providerId": "openai", "model": "gpt-4o-mini" }, "roles": { "title": { "model": "gpt-4o-mini" } } }\` → 启 daemon → 发首轮 → \`GET /sessions/:id\` 看到 title 被改

## Out of scope
- compaction（PR-B）
- plan / build（PR-C）
- title 重新生成 / 手动编辑

## Related
Closes #18