### PR TITLE
feat(daemon): compact session history when it exceeds size threshold

### DIFF
--- a/apps/daemon/src/http/chat.ts
+++ b/apps/daemon/src/http/chat.ts
@@ -4,6 +4,7 @@ import type { ProviderRegistry } from '../providers/registry';
 import type { AgentEvent, ProviderId } from '../providers/types';
 import type { RoleResolver } from '../roles/resolver';
 import type { FileSessionStore, Session } from '../sessions/store';
+import { maybeCompact } from '../tasks/compaction';
 import { generateTitle } from '../tasks/title';
 import { sseStream } from './sse';
 
@@ -58,6 +59,15 @@ export function chatRouter(
     }
 
     session = await store.appendMessage(session.id, parsed.data.message);
+
+    const compaction = await maybeCompact({
+      registry,
+      resolver: roles,
+      messages: session.messages,
+    });
+    if (compaction.compacted) {
+      session = await store.replaceMessages(session.id, compaction.messages);
+    }
 
     const ac = new AbortController();
     c.req.raw.signal.addEventListener('abort', () => ac.abort(), { once: true });

--- a/apps/daemon/src/sessions/store.test.ts
+++ b/apps/daemon/src/sessions/store.test.ts
@@ -108,6 +108,30 @@ describe('FileSessionStore.appendMessage', () => {
   });
 });
 
+describe('FileSessionStore.replaceMessages', () => {
+  it('overwrites the whole message list', async () => {
+    const s = await store.create({ providerId: 'openai' });
+    await store.appendMessage(s.id, { role: 'user', content: 'turn 1' });
+    await store.appendMessage(s.id, { role: 'assistant', content: 'reply 1' });
+    const after = await store.replaceMessages(s.id, [
+      { role: 'system', content: 'compacted' },
+    ]);
+    expect(after.messages).toEqual([
+      { role: 'system', content: 'compacted' },
+    ]);
+    const reread = await store.get(s.id);
+    expect(reread?.messages).toEqual([
+      { role: 'system', content: 'compacted' },
+    ]);
+  });
+
+  it('throws when the session is missing', async () => {
+    await expect(
+      store.replaceMessages('nope', []),
+    ).rejects.toThrow(/nope/);
+  });
+});
+
 describe('FileSessionStore.setTitle', () => {
   it('overwrites the title and bumps updatedAt', async () => {
     const s = await store.create({ providerId: 'openai', title: 'old' });

--- a/apps/daemon/src/sessions/store.ts
+++ b/apps/daemon/src/sessions/store.ts
@@ -94,6 +94,18 @@ export class FileSessionStore {
     await this.write(session);
   }
 
+  async replaceMessages(
+    id: string,
+    messages: SessionMessage[],
+  ): Promise<Session> {
+    const session = await this.get(id);
+    if (!session) throw new Error(`session not found: ${id}`);
+    session.messages = messages;
+    session.updatedAt = new Date().toISOString();
+    await this.write(session);
+    return session;
+  }
+
   async delete(id: string): Promise<void> {
     try {
       await unlink(this.fileFor(id));

--- a/apps/daemon/src/tasks/compaction.test.ts
+++ b/apps/daemon/src/tasks/compaction.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'bun:test';
+import { ProviderRegistry } from '../providers/registry';
+import type { Provider, ChatRequest, AgentEvent, ChatMessage } from '../providers/types';
+import { RoleResolver } from '../roles/resolver';
+import { maybeCompact } from './compaction';
+
+function makeProvider(reply: string): Provider {
+  return {
+    id: 'openai',
+    displayName: 'openai',
+    authMode: 'apiKey',
+    status: async () => ({ loggedIn: true }),
+    chat: function (_req: ChatRequest): AsyncIterable<AgentEvent> {
+      return (async function* () {
+        yield { type: 'text-delta', text: reply };
+        yield { type: 'done' };
+      })();
+    },
+  };
+}
+
+function makeRegistry(provider: Provider): ProviderRegistry {
+  const r = new ProviderRegistry();
+  r.register(provider);
+  return r;
+}
+
+function bigMessage(role: ChatMessage['role'], content: string): ChatMessage {
+  return { role, content };
+}
+
+describe('maybeCompact', () => {
+  const resolver = new RoleResolver({ providerId: 'openai' }, {});
+
+  it('returns the original messages when total chars stay under threshold', async () => {
+    const messages: ChatMessage[] = [
+      bigMessage('user', 'a'),
+      bigMessage('assistant', 'b'),
+      bigMessage('user', 'c'),
+    ];
+    const out = await maybeCompact({
+      registry: makeRegistry(makeProvider('summary')),
+      resolver,
+      messages,
+      thresholdChars: 100,
+      keepRecent: 2,
+    });
+    expect(out.compacted).toBe(false);
+    expect(out.messages).toEqual(messages);
+  });
+
+  it('returns the original messages when there are fewer than keep + 1', async () => {
+    const messages: ChatMessage[] = [
+      bigMessage('user', 'a'.repeat(500)),
+      bigMessage('assistant', 'b'.repeat(500)),
+    ];
+    const out = await maybeCompact({
+      registry: makeRegistry(makeProvider('summary')),
+      resolver,
+      messages,
+      thresholdChars: 100,
+      keepRecent: 4,
+    });
+    expect(out.compacted).toBe(false);
+    expect(out.messages).toEqual(messages);
+  });
+
+  it('replaces older messages with a system summary and keeps the recent ones', async () => {
+    const messages: ChatMessage[] = [
+      bigMessage('user', 'old-1 ' + 'x'.repeat(200)),
+      bigMessage('assistant', 'old-2 ' + 'x'.repeat(200)),
+      bigMessage('user', 'old-3 ' + 'x'.repeat(200)),
+      bigMessage('assistant', 'old-4 ' + 'x'.repeat(200)),
+      bigMessage('user', 'recent-A'),
+      bigMessage('assistant', 'recent-B'),
+      bigMessage('user', 'recent-C'),
+    ];
+    const out = await maybeCompact({
+      registry: makeRegistry(makeProvider('Earlier work covered topics X and Y.')),
+      resolver,
+      messages,
+      thresholdChars: 100,
+      keepRecent: 3,
+    });
+    expect(out.compacted).toBe(true);
+    expect(out.messages).toHaveLength(4);
+    expect(out.messages[0]?.role).toBe('system');
+    expect(out.messages[0]?.content).toContain(
+      'Earlier work covered topics X and Y.',
+    );
+    expect(out.messages.slice(1)).toEqual([
+      bigMessage('user', 'recent-A'),
+      bigMessage('assistant', 'recent-B'),
+      bigMessage('user', 'recent-C'),
+    ]);
+  });
+
+  it('falls back to the original messages when the LLM call fails', async () => {
+    const failing: Provider = {
+      id: 'openai',
+      displayName: 'openai',
+      authMode: 'apiKey',
+      status: async () => ({ loggedIn: true }),
+      chat: function (): AsyncIterable<AgentEvent> {
+        return (async function* () {
+          yield { type: 'error', message: 'rate limit' };
+        })();
+      },
+    };
+    const messages: ChatMessage[] = Array.from({ length: 10 }, (_, i) =>
+      bigMessage(i % 2 === 0 ? 'user' : 'assistant', 'x'.repeat(100)),
+    );
+    const out = await maybeCompact({
+      registry: makeRegistry(failing),
+      resolver,
+      messages,
+      thresholdChars: 100,
+      keepRecent: 3,
+    });
+    expect(out.compacted).toBe(false);
+    expect(out.messages).toEqual(messages);
+  });
+
+  it('falls back when compaction role has no providerId', async () => {
+    const noResolver = new RoleResolver({}, {});
+    const messages: ChatMessage[] = Array.from({ length: 10 }, (_, i) =>
+      bigMessage(i % 2 === 0 ? 'user' : 'assistant', 'x'.repeat(100)),
+    );
+    const out = await maybeCompact({
+      registry: makeRegistry(makeProvider('summary')),
+      resolver: noResolver,
+      messages,
+      thresholdChars: 100,
+      keepRecent: 3,
+    });
+    expect(out.compacted).toBe(false);
+    expect(out.messages).toEqual(messages);
+  });
+});

--- a/apps/daemon/src/tasks/compaction.ts
+++ b/apps/daemon/src/tasks/compaction.ts
@@ -1,0 +1,88 @@
+import type { ProviderRegistry } from '../providers/registry';
+import type { ChatMessage } from '../providers/types';
+import type { RoleResolver } from '../roles/resolver';
+import { runOneShot } from './runOneShot';
+
+const DEFAULT_THRESHOLD_CHARS = 32_000;
+const DEFAULT_KEEP_RECENT = 4;
+
+const SYSTEM_PROMPT =
+  'You compress conversation histories. Output 2-4 short paragraphs of plain prose summarizing the key facts, decisions, code identifiers, and any open threads. No markdown headers or bullet lists.';
+
+export type MaybeCompactInput = {
+  registry: ProviderRegistry;
+  resolver: RoleResolver;
+  messages: ChatMessage[];
+  thresholdChars?: number;
+  keepRecent?: number;
+  signal?: AbortSignal;
+};
+
+export type CompactionResult = {
+  compacted: boolean;
+  messages: ChatMessage[];
+};
+
+export async function maybeCompact(
+  input: MaybeCompactInput,
+): Promise<CompactionResult> {
+  const threshold = input.thresholdChars ?? DEFAULT_THRESHOLD_CHARS;
+  const keep = input.keepRecent ?? DEFAULT_KEEP_RECENT;
+
+  if (totalChars(input.messages) <= threshold) {
+    return { compacted: false, messages: input.messages };
+  }
+  if (input.messages.length <= keep + 1) {
+    return { compacted: false, messages: input.messages };
+  }
+  if (!input.resolver.resolve('compaction').providerId) {
+    return { compacted: false, messages: input.messages };
+  }
+
+  const olderEnd = input.messages.length - keep;
+  const older = input.messages.slice(0, olderEnd);
+  const recent = input.messages.slice(olderEnd);
+
+  const transcript = older
+    .map((m) => `[${m.role}] ${m.content}`)
+    .join('\n\n');
+
+  let summary: string;
+  try {
+    summary = await runOneShot({
+      registry: input.registry,
+      resolver: input.resolver,
+      role: 'compaction',
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        {
+          role: 'user',
+          content: `Summarize the following conversation history:\n\n${transcript}`,
+        },
+      ],
+      signal: input.signal,
+    });
+  } catch (err) {
+    console.warn('compaction failed, proceeding with full history:', err);
+    return { compacted: false, messages: input.messages };
+  }
+
+  if (!summary) {
+    return { compacted: false, messages: input.messages };
+  }
+
+  return {
+    compacted: true,
+    messages: [
+      {
+        role: 'system',
+        content: `[Earlier conversation summary]\n${summary}`,
+      },
+      ...recent,
+    ],
+  };
+}
+
+function totalChars(messages: ChatMessage[]): number {
+  return messages.reduce((sum, m) => sum + m.content.length, 0);
+}

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -113,7 +113,9 @@ flowchart TB
 
 两层共用底层 provider，但接口形状不同。**所有调用都通过 `RoleResolver.resolve(name)` 拿 `{ providerId, model }`**，调用方不直接读 config。这让"给 title 单独配个便宜模型"成为一行 config 改动。
 
-当前已落地：`title`（首轮 user+assistant 后异步生成会话标题）。
+当前已落地：
+- `title`（首轮 user+assistant 后异步生成会话标题）
+- `compaction`（每轮调 provider 前估字符数；超阈值时把"老消息"换成一条 `system` 总结，保留最近 K 条原文）
 
 ## 关键决策
 


### PR DESCRIPTION
## Summary
长对话会撑爆 provider 的 context window 还推高每轮 token 成本。引入 opportunistic compaction：
每轮调 provider 之前估一下消息总字符数，超阈值（默认 32K 字符）就把"早期消息"喂给 \`compaction\` role 做总结，替换成一条 \`system\` 摘要并保留最近 K 条（默认 4 条）原文。

走的是 PR #19 的 \`runOneShot\` + role config 路径。

## Changes
- \`apps/daemon/src/tasks/compaction.ts\`：\`maybeCompact\` 计算阈值、切分新旧、调 compaction role、组装新消息列表；compaction role 未配置 / 消息太少 / LLM 失败一律安全降级为不压缩
- \`apps/daemon/src/sessions/store.ts\`：\`FileSessionStore.replaceMessages\` 一次替换整段 messages（沿用原子 rename）
- \`apps/daemon/src/http/chat.ts\`：\`appendMessage(user)\` 之后、provider 调用之前跑 \`maybeCompact\`；压缩成功就 \`replaceMessages\` 并用新列表喂 provider
- \`docs/architecture/overview.md\`：多 agent 已落地清单加 compaction

## Test plan
- [x] \`bun test\`（97 passed）
- [x] \`bun run check\`
- [ ] 手动：\`config.json\` 加 \`roles.compaction.providerId\`，跑足够长的对话观察 \`session.messages\` 变成 \`[system summary, ...recent]\`

## Out of scope
- 阈值变 config 项
- 按 turn / 实际 token 估算（现在按字符数粗估，1 token≈4 char）
- UI 提示"已压缩"

## Related
Closes #20