### PR TITLE
feat: add plan/build agents with task checklist UI

### DIFF
--- a/apps/daemon/src/agents/build.test.ts
+++ b/apps/daemon/src/agents/build.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'bun:test';
+import { ProviderRegistry } from '../providers/registry';
+import type { Provider, ChatRequest, AgentEvent } from '../providers/types';
+import { RoleResolver } from '../roles/resolver';
+import { runBuild } from './build';
+import type { PlanTask } from './types';
+
+type Call = { messages: ChatRequest['messages'] };
+
+function fakeProvider(replies: string[], log: Call[] = []): Provider {
+  let i = 0;
+  return {
+    id: 'openai',
+    displayName: 'openai',
+    authMode: 'apiKey',
+    status: async () => ({ loggedIn: true }),
+    chat: function (req: ChatRequest): AsyncIterable<AgentEvent> {
+      log.push({ messages: req.messages });
+      const text = replies[i++] ?? 'ok';
+      return (async function* () {
+        yield { type: 'text-delta', text };
+        yield { type: 'done' };
+      })();
+    },
+  };
+}
+
+function tasks(...titles: string[]): PlanTask[] {
+  return titles.map((t, i) => ({ id: `t${i + 1}`, title: t }));
+}
+
+async function collect(it: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const ev of it) out.push(ev);
+  return out;
+}
+
+describe('runBuild', () => {
+  it('streams task-start, taskId-tagged text-delta, task-done per task', async () => {
+    const log: Call[] = [];
+    const registry = new ProviderRegistry();
+    registry.register(fakeProvider(['result A', 'result B'], log));
+    const events = await collect(
+      runBuild({
+        registry,
+        resolver: new RoleResolver({ providerId: 'openai' }, {}),
+        sessionMessages: [{ role: 'user', content: 'do it' }],
+        tasks: tasks('first step', 'second step'),
+        sessionFallback: { providerId: 'openai' },
+      }),
+    );
+
+    const types = events.map((e) => e.type);
+    expect(types).toEqual([
+      'task-start',
+      'text-delta',
+      'task-done',
+      'task-start',
+      'text-delta',
+      'task-done',
+      'done',
+    ]);
+
+    const deltas = events.filter(
+      (e): e is Extract<AgentEvent, { type: 'text-delta' }> =>
+        e.type === 'text-delta',
+    );
+    expect(deltas[0]?.taskId).toBe('t1');
+    expect(deltas[0]?.text).toBe('result A');
+    expect(deltas[1]?.taskId).toBe('t2');
+    expect(deltas[1]?.text).toBe('result B');
+  });
+
+  it('feeds prior task results into subsequent provider calls', async () => {
+    const log: Call[] = [];
+    const registry = new ProviderRegistry();
+    registry.register(fakeProvider(['result A', 'result B'], log));
+    await collect(
+      runBuild({
+        registry,
+        resolver: new RoleResolver({ providerId: 'openai' }, {}),
+        sessionMessages: [{ role: 'user', content: 'original query' }],
+        tasks: tasks('first step', 'second step'),
+        sessionFallback: { providerId: 'openai' },
+      }),
+    );
+
+    expect(log).toHaveLength(2);
+    // The second call should see the first task's result in its context.
+    const secondMessages = log[1]?.messages ?? [];
+    const flat = secondMessages.map((m) => m.content).join('\n');
+    expect(flat).toContain('original query');
+    expect(flat).toContain('result A');
+    expect(flat).toContain('second step');
+  });
+
+  it('emits task-done with ok:false and an error event when a task fails, then stops', async () => {
+    const failing: Provider = {
+      id: 'openai',
+      displayName: 'openai',
+      authMode: 'apiKey',
+      status: async () => ({ loggedIn: true }),
+      chat: function (): AsyncIterable<AgentEvent> {
+        return (async function* () {
+          yield { type: 'error', message: 'rate limit' };
+        })();
+      },
+    };
+    const registry = new ProviderRegistry();
+    registry.register(failing);
+    const events = await collect(
+      runBuild({
+        registry,
+        resolver: new RoleResolver({ providerId: 'openai' }, {}),
+        sessionMessages: [{ role: 'user', content: 'q' }],
+        tasks: tasks('task 1', 'task 2'),
+        sessionFallback: { providerId: 'openai' },
+      }),
+    );
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain('task-done');
+    const done = events.find(
+      (e): e is Extract<AgentEvent, { type: 'task-done' }> =>
+        e.type === 'task-done',
+    );
+    expect(done?.ok).toBe(false);
+    // Should not start the second task.
+    expect(types.filter((t) => t === 'task-start')).toHaveLength(1);
+    expect(types).toContain('error');
+  });
+});

--- a/apps/daemon/src/agents/build.ts
+++ b/apps/daemon/src/agents/build.ts
@@ -1,0 +1,122 @@
+import type { ProviderRegistry } from '../providers/registry';
+import type {
+  AgentEvent,
+  ChatMessage,
+  ProviderId,
+} from '../providers/types';
+import type { RoleResolver } from '../roles/resolver';
+import type { PlanTask } from './types';
+
+export type SessionFallback = {
+  providerId: string;
+  model?: string;
+};
+
+export type RunBuildInput = {
+  registry: ProviderRegistry;
+  resolver: RoleResolver;
+  sessionMessages: ChatMessage[];
+  tasks: PlanTask[];
+  sessionFallback: SessionFallback;
+  signal?: AbortSignal;
+};
+
+const TASK_INSTRUCTION_PREFIX =
+  'Now execute this task and respond with the result of this task only. Do not narrate the next step.';
+
+export async function* runBuild(
+  input: RunBuildInput,
+): AsyncIterable<AgentEvent> {
+  const { providerId, model } = resolveAgent(
+    input.resolver,
+    'build',
+    input.sessionFallback,
+  );
+  const provider = input.registry.get(providerId);
+  if (!provider) {
+    yield { type: 'error', message: `provider '${providerId}' is not registered` };
+    return;
+  }
+
+  const completed: Array<{ task: PlanTask; result: string }> = [];
+
+  for (const task of input.tasks) {
+    yield { type: 'task-start', id: task.id };
+
+    const messages = composeTaskMessages(
+      input.sessionMessages,
+      completed,
+      task,
+    );
+
+    let buf = '';
+    let failed = false;
+    let lastError: string | null = null;
+
+    for await (const ev of provider.chat({
+      providerId: provider.id as ProviderId,
+      model,
+      messages,
+      signal: input.signal,
+    })) {
+      if (ev.type === 'text-delta') {
+        buf += ev.text;
+        yield { type: 'text-delta', text: ev.text, taskId: task.id };
+      } else if (ev.type === 'error') {
+        failed = true;
+        lastError = ev.message;
+        break;
+      }
+      // tool-call / tool-result are forwarded too, scoped by taskId? For now
+      // build doesn't surface them — no tools wired yet.
+    }
+
+    yield { type: 'task-done', id: task.id, ok: !failed };
+
+    if (failed) {
+      yield { type: 'error', message: lastError ?? 'task failed' };
+      return;
+    }
+
+    completed.push({ task, result: buf });
+  }
+
+  yield { type: 'done' };
+}
+
+function composeTaskMessages(
+  sessionMessages: ChatMessage[],
+  completed: Array<{ task: PlanTask; result: string }>,
+  current: PlanTask,
+): ChatMessage[] {
+  const priorTaskNotes: ChatMessage[] = completed.flatMap(
+    ({ task, result }) => [
+      {
+        role: 'assistant' as const,
+        content: `[Completed task: ${task.title}]\n${result}`,
+      },
+    ],
+  );
+
+  const instruction = current.hint
+    ? `${TASK_INSTRUCTION_PREFIX}\n\nTask: **${current.title}**\nDetail: ${current.hint}`
+    : `${TASK_INSTRUCTION_PREFIX}\n\nTask: **${current.title}**`;
+
+  return [
+    ...sessionMessages,
+    ...priorTaskNotes,
+    { role: 'user', content: instruction },
+  ];
+}
+
+function resolveAgent(
+  resolver: RoleResolver,
+  role: string,
+  fallback: SessionFallback,
+): { providerId: string; model?: string } {
+  const r = resolver.resolve(role);
+  return {
+    providerId: r.providerId ?? fallback.providerId,
+    model: r.model ?? fallback.model,
+  };
+}

--- a/apps/daemon/src/agents/orchestrator.test.ts
+++ b/apps/daemon/src/agents/orchestrator.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'bun:test';
+import { ProviderRegistry } from '../providers/registry';
+import type { Provider, ChatRequest, AgentEvent } from '../providers/types';
+import { RoleResolver } from '../roles/resolver';
+import { runChat } from './orchestrator';
+
+function sequenceProvider(replies: string[]): Provider {
+  let i = 0;
+  return {
+    id: 'openai',
+    displayName: 'openai',
+    authMode: 'apiKey',
+    status: async () => ({ loggedIn: true }),
+    chat: function (_req: ChatRequest): AsyncIterable<AgentEvent> {
+      const text = replies[i++] ?? '';
+      return (async function* () {
+        if (text) yield { type: 'text-delta', text };
+        yield { type: 'done' };
+      })();
+    },
+  };
+}
+
+async function collect(
+  it: AsyncIterable<AgentEvent>,
+): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const ev of it) out.push(ev);
+  return out;
+}
+
+describe('runChat (orchestrator)', () => {
+  const sessionFallback = { providerId: 'openai' };
+
+  it('takes the direct path when plan returns direct', async () => {
+    const registry = new ProviderRegistry();
+    registry.register(sequenceProvider(['{"kind":"direct"}', 'hello world']));
+    const events = await collect(
+      runChat({
+        registry,
+        resolver: new RoleResolver({ providerId: 'openai' }, {}),
+        sessionMessages: [{ role: 'user', content: 'simple question' }],
+        sessionFallback,
+      }),
+    );
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain('plan');
+    expect(types).not.toContain('task-start');
+    expect(types).toContain('text-delta');
+    expect(types[types.length - 1]).toBe('done');
+  });
+
+  it('takes the planned path when plan returns tasks', async () => {
+    const registry = new ProviderRegistry();
+    registry.register(
+      sequenceProvider([
+        '{"kind":"tasks","tasks":[{"title":"first"},{"title":"second"}]}',
+        'result of first',
+        'result of second',
+      ]),
+    );
+    const events = await collect(
+      runChat({
+        registry,
+        resolver: new RoleResolver({ providerId: 'openai' }, {}),
+        sessionMessages: [{ role: 'user', content: 'multi-step ask' }],
+        sessionFallback,
+      }),
+    );
+
+    const planEv = events.find((e) => e.type === 'plan') as
+      | Extract<AgentEvent, { type: 'plan' }>
+      | undefined;
+    expect(planEv?.tasks).toHaveLength(2);
+    expect(planEv?.tasks[0]?.title).toBe('first');
+
+    const taskStarts = events.filter((e) => e.type === 'task-start');
+    expect(taskStarts).toHaveLength(2);
+    expect(events[events.length - 1]?.type).toBe('done');
+  });
+
+  it('falls back to direct when plan role is unconfigured', async () => {
+    const registry = new ProviderRegistry();
+    registry.register(sequenceProvider(['plain answer']));
+    const events = await collect(
+      runChat({
+        registry,
+        resolver: new RoleResolver({}, {}),
+        sessionMessages: [{ role: 'user', content: 'hi' }],
+        sessionFallback,
+      }),
+    );
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain('plan');
+    expect(types).toContain('text-delta');
+  });
+});

--- a/apps/daemon/src/agents/orchestrator.ts
+++ b/apps/daemon/src/agents/orchestrator.ts
@@ -1,0 +1,68 @@
+import type { ProviderRegistry } from '../providers/registry';
+import type {
+  AgentEvent,
+  ChatMessage,
+  ProviderId,
+} from '../providers/types';
+import type { RoleResolver } from '../roles/resolver';
+import { runBuild, type SessionFallback } from './build';
+import { runPlan } from './plan';
+
+export type RunChatInput = {
+  registry: ProviderRegistry;
+  resolver: RoleResolver;
+  sessionMessages: ChatMessage[];
+  sessionFallback: SessionFallback;
+  signal?: AbortSignal;
+};
+
+export async function* runChat(
+  input: RunChatInput,
+): AsyncIterable<AgentEvent> {
+  const plan = await runPlan({
+    registry: input.registry,
+    resolver: input.resolver,
+    messages: input.sessionMessages,
+    signal: input.signal,
+  });
+
+  if (plan.kind === 'tasks') {
+    yield {
+      type: 'plan',
+      tasks: plan.tasks.map((t) => {
+        const out: { id: string; title: string; hint?: string } = {
+          id: t.id,
+          title: t.title,
+        };
+        if (t.hint) out.hint = t.hint;
+        return out;
+      }),
+    };
+    yield* runBuild({
+      registry: input.registry,
+      resolver: input.resolver,
+      sessionMessages: input.sessionMessages,
+      tasks: plan.tasks,
+      sessionFallback: input.sessionFallback,
+      signal: input.signal,
+    });
+    return;
+  }
+
+  // Direct path: stream the build provider once with the original messages.
+  const buildResolved = input.resolver.resolve('build');
+  const providerId = buildResolved.providerId ?? input.sessionFallback.providerId;
+  const model = buildResolved.model ?? input.sessionFallback.model;
+  const provider = input.registry.get(providerId);
+  if (!provider) {
+    yield { type: 'error', message: `provider '${providerId}' is not registered` };
+    return;
+  }
+
+  yield* provider.chat({
+    providerId: provider.id as ProviderId,
+    model,
+    messages: input.sessionMessages,
+    signal: input.signal,
+  });
+}

--- a/apps/daemon/src/agents/plan.test.ts
+++ b/apps/daemon/src/agents/plan.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'bun:test';
+import { ProviderRegistry } from '../providers/registry';
+import type { Provider, ChatRequest, AgentEvent } from '../providers/types';
+import { RoleResolver } from '../roles/resolver';
+import { runPlan } from './plan';
+
+function reply(text: string): Provider {
+  return {
+    id: 'openai',
+    displayName: 'openai',
+    authMode: 'apiKey',
+    status: async () => ({ loggedIn: true }),
+    chat: function (_req: ChatRequest): AsyncIterable<AgentEvent> {
+      return (async function* () {
+        yield { type: 'text-delta', text };
+        yield { type: 'done' };
+      })();
+    },
+  };
+}
+
+function harness(text: string) {
+  const r = new ProviderRegistry();
+  r.register(reply(text));
+  return {
+    registry: r,
+    resolver: new RoleResolver({ providerId: 'openai' }, {}),
+  };
+}
+
+describe('runPlan', () => {
+  it('parses {kind:"direct"} and returns direct', async () => {
+    const out = await runPlan({
+      ...harness('{"kind":"direct"}'),
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(out).toEqual({ kind: 'direct' });
+  });
+
+  it('parses tasks JSON and assigns ids', async () => {
+    const out = await runPlan({
+      ...harness(
+        '{"kind":"tasks","tasks":[{"title":"first step"},{"title":"second step","hint":"detail"}]}',
+      ),
+      messages: [{ role: 'user', content: 'do something complex' }],
+    });
+    expect(out.kind).toBe('tasks');
+    if (out.kind !== 'tasks') return;
+    expect(out.tasks).toHaveLength(2);
+    expect(out.tasks[0]?.title).toBe('first step');
+    expect(out.tasks[1]?.hint).toBe('detail');
+    expect(out.tasks[0]?.id).toMatch(/.+/);
+    expect(out.tasks[0]?.id).not.toBe(out.tasks[1]?.id);
+  });
+
+  it('strips ```json fences before parsing', async () => {
+    const out = await runPlan({
+      ...harness('```json\n{"kind":"direct"}\n```'),
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(out).toEqual({ kind: 'direct' });
+  });
+
+  it('falls back to direct on malformed JSON', async () => {
+    const out = await runPlan({
+      ...harness('this is not json'),
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(out).toEqual({ kind: 'direct' });
+  });
+
+  it('falls back to direct when plan role is unconfigured', async () => {
+    const r = new ProviderRegistry();
+    r.register(reply('{"kind":"tasks","tasks":[{"title":"x"}]}'));
+    const out = await runPlan({
+      registry: r,
+      resolver: new RoleResolver({}, {}),
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(out).toEqual({ kind: 'direct' });
+  });
+
+  it('falls back to direct when tasks list is empty', async () => {
+    const out = await runPlan({
+      ...harness('{"kind":"tasks","tasks":[]}'),
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(out).toEqual({ kind: 'direct' });
+  });
+});

--- a/apps/daemon/src/agents/plan.ts
+++ b/apps/daemon/src/agents/plan.ts
@@ -1,0 +1,101 @@
+import type { ProviderRegistry } from '../providers/registry';
+import type { ChatMessage } from '../providers/types';
+import type { RoleResolver } from '../roles/resolver';
+import { runOneShot } from '../tasks/runOneShot';
+import type { PlanResult, PlanTask } from './types';
+
+const SYSTEM_PROMPT = [
+  'You are a planner. Look at the user\'s most recent request and decide if it needs multi-step decomposition.',
+  '',
+  'If the request is simple (a question, a definition, basic chat, a single edit), respond with EXACTLY:',
+  '{"kind":"direct"}',
+  '',
+  'If the request needs multiple steps (research, comparison across sources, building something with several parts), respond with:',
+  '{"kind":"tasks","tasks":[{"title":"<4-8 word phrase>","hint":"<one sentence detail, optional>"}, ...]}',
+  '',
+  'Use 2 to 5 tasks. Each title is short and user-readable. Output ONLY the JSON. No code fences, no preamble, no trailing text.',
+].join('\n');
+
+export type RunPlanInput = {
+  registry: ProviderRegistry;
+  resolver: RoleResolver;
+  messages: ChatMessage[];
+  signal?: AbortSignal;
+};
+
+export async function runPlan(input: RunPlanInput): Promise<PlanResult> {
+  if (!input.resolver.resolve('plan').providerId) {
+    return { kind: 'direct' };
+  }
+
+  let raw: string;
+  try {
+    raw = await runOneShot({
+      registry: input.registry,
+      resolver: input.resolver,
+      role: 'plan',
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        ...input.messages,
+      ],
+      signal: input.signal,
+    });
+  } catch (err) {
+    console.warn('plan generation failed, falling back to direct:', err);
+    return { kind: 'direct' };
+  }
+
+  return parsePlan(raw);
+}
+
+export function parsePlan(raw: string): PlanResult {
+  const cleaned = stripCodeFence(raw).trim();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    return { kind: 'direct' };
+  }
+
+  if (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    (parsed as { kind?: unknown }).kind === 'direct'
+  ) {
+    return { kind: 'direct' };
+  }
+
+  if (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    (parsed as { kind?: unknown }).kind === 'tasks' &&
+    Array.isArray((parsed as { tasks?: unknown }).tasks)
+  ) {
+    const rawTasks = (parsed as { tasks: unknown[] }).tasks;
+    const tasks: PlanTask[] = [];
+    for (const t of rawTasks) {
+      if (typeof t !== 'object' || t === null) continue;
+      const title = (t as { title?: unknown }).title;
+      if (typeof title !== 'string' || title.length === 0) continue;
+      const hintRaw = (t as { hint?: unknown }).hint;
+      const task: PlanTask = {
+        id: crypto.randomUUID(),
+        title,
+      };
+      if (typeof hintRaw === 'string' && hintRaw.length > 0) {
+        task.hint = hintRaw;
+      }
+      tasks.push(task);
+    }
+    if (tasks.length === 0) return { kind: 'direct' };
+    return { kind: 'tasks', tasks };
+  }
+
+  return { kind: 'direct' };
+}
+
+function stripCodeFence(text: string): string {
+  const fenced = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/m);
+  if (fenced && fenced[1]) return fenced[1];
+  return text;
+}

--- a/apps/daemon/src/agents/types.ts
+++ b/apps/daemon/src/agents/types.ts
@@ -1,0 +1,17 @@
+export type PlanTask = {
+  id: string;
+  title: string;
+  hint?: string;
+};
+
+export type PlanResult =
+  | { kind: 'direct' }
+  | { kind: 'tasks'; tasks: PlanTask[] };
+
+export type TaskRecord = {
+  id: string;
+  title: string;
+  hint?: string;
+  status: 'done' | 'failed';
+  result: string;
+};

--- a/apps/daemon/src/http/chat.ts
+++ b/apps/daemon/src/http/chat.ts
@@ -1,9 +1,15 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { runChat } from '../agents/orchestrator';
+import type { TaskRecord } from '../agents/types';
 import type { ProviderRegistry } from '../providers/registry';
-import type { AgentEvent, ProviderId } from '../providers/types';
+import type { AgentEvent } from '../providers/types';
 import type { RoleResolver } from '../roles/resolver';
-import type { FileSessionStore, Session } from '../sessions/store';
+import type {
+  FileSessionStore,
+  Session,
+  SessionMessage,
+} from '../sessions/store';
 import { maybeCompact } from '../tasks/compaction';
 import { generateTitle } from '../tasks/title';
 import { sseStream } from './sse';
@@ -53,8 +59,7 @@ export function chatRouter(
       });
     }
 
-    const provider = registry.get(session.providerId);
-    if (!provider) {
+    if (!registry.get(session.providerId)) {
       return c.json({ error: `unknown providerId: ${session.providerId}` }, 404);
     }
 
@@ -72,20 +77,26 @@ export function chatRouter(
     const ac = new AbortController();
     c.req.raw.signal.addEventListener('abort', () => ac.abort(), { once: true });
 
-    const events = provider.chat({
-      providerId: provider.id as ProviderId,
-      model: parsed.data.model ?? session.model,
-      messages: session.messages,
+    const events = runChat({
+      registry,
+      resolver: roles,
+      sessionMessages: session.messages,
+      sessionFallback: {
+        providerId: session.providerId,
+        model: parsed.data.model ?? session.model,
+      },
       signal: ac.signal,
     });
 
     const sessionId = session.id;
-    const persisted = persistAssistant(events, async (text) => {
-      if (text.length === 0) return;
-      const updated = await store.appendMessage(sessionId, {
+    const persisted = persistAssistant(events, async (collected) => {
+      if (collected.content.length === 0 && !collected.plan) return;
+      const msg: SessionMessage = {
         role: 'assistant',
-        content: text,
-      });
+        content: collected.content,
+      };
+      if (collected.plan) msg.plan = collected.plan;
+      const updated = await store.appendMessage(sessionId, msg);
       maybeGenerateTitle(updated, registry, roles, store);
     });
 
@@ -102,23 +113,77 @@ export function chatRouter(
   return app;
 }
 
+type CollectedAssistant = {
+  content: string;
+  plan?: { tasks: TaskRecord[] };
+};
+
 async function* persistAssistant(
   source: AsyncIterable<AgentEvent>,
-  onComplete: (text: string) => Promise<void>,
+  onComplete: (collected: CollectedAssistant) => Promise<void>,
 ): AsyncIterable<AgentEvent> {
-  let buf = '';
+  const collector = createCollector();
   try {
     for await (const ev of source) {
-      if (ev.type === 'text-delta') buf += ev.text;
+      collector.observe(ev);
       yield ev;
     }
   } finally {
     try {
-      await onComplete(buf);
+      await onComplete(collector.result());
     } catch (err) {
       console.error('failed to persist assistant message:', err);
     }
   }
+}
+
+function createCollector(): {
+  observe(ev: AgentEvent): void;
+  result(): CollectedAssistant;
+} {
+  let directBuf = '';
+  let planTasks: Array<{ id: string; title: string; hint?: string }> | null =
+    null;
+  const taskBufs = new Map<string, string>();
+  const taskStatus = new Map<string, 'done' | 'failed'>();
+
+  return {
+    observe(ev) {
+      if (ev.type === 'plan') {
+        planTasks = ev.tasks;
+        return;
+      }
+      if (ev.type === 'text-delta') {
+        if (ev.taskId) {
+          taskBufs.set(ev.taskId, (taskBufs.get(ev.taskId) ?? '') + ev.text);
+        } else {
+          directBuf += ev.text;
+        }
+        return;
+      }
+      if (ev.type === 'task-done') {
+        taskStatus.set(ev.id, ev.ok ? 'done' : 'failed');
+      }
+    },
+    result() {
+      if (!planTasks) return { content: directBuf };
+      const tasks: TaskRecord[] = planTasks.map((t) => {
+        const rec: TaskRecord = {
+          id: t.id,
+          title: t.title,
+          status: taskStatus.get(t.id) ?? 'failed',
+          result: taskBufs.get(t.id) ?? '',
+        };
+        if (t.hint) rec.hint = t.hint;
+        return rec;
+      });
+      const content = tasks
+        .map((t) => t.result)
+        .filter((r) => r.length > 0)
+        .join('\n\n');
+      return { content, plan: { tasks } };
+    },
+  };
 }
 
 function maybeGenerateTitle(

--- a/apps/daemon/src/providers/types.ts
+++ b/apps/daemon/src/providers/types.ts
@@ -13,7 +13,7 @@ export type ChatRequest = {
 };
 
 export type AgentEvent =
-  | { type: 'text-delta'; text: string }
+  | { type: 'text-delta'; text: string; taskId?: string }
   | { type: 'tool-call'; id: string; name: string; args: unknown }
   | {
       type: 'tool-result';
@@ -22,6 +22,12 @@ export type AgentEvent =
       result?: unknown;
       error?: string;
     }
+  | {
+      type: 'plan';
+      tasks: Array<{ id: string; title: string; hint?: string }>;
+    }
+  | { type: 'task-start'; id: string }
+  | { type: 'task-done'; id: string; ok: boolean }
   | {
       type: 'done';
       sessionId?: string;

--- a/apps/daemon/src/sessions/store.ts
+++ b/apps/daemon/src/sessions/store.ts
@@ -1,9 +1,11 @@
 import { mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import type { TaskRecord } from '../agents/types';
 
 export type SessionMessage = {
   role: 'user' | 'assistant' | 'system';
   content: string;
+  plan?: { tasks: TaskRecord[] };
 };
 
 export type Session = {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -103,10 +103,39 @@ export function App() {
 
       for await (const event of events) {
         if (event.type === 'text-delta') {
+          if (event.taskId) {
+            dispatch({
+              type: 'message/task-delta',
+              id: assistantId,
+              taskId: event.taskId,
+              text: event.text,
+            });
+          } else {
+            dispatch({
+              type: 'message/append-delta',
+              id: assistantId,
+              text: event.text,
+            });
+          }
+        } else if (event.type === 'plan') {
           dispatch({
-            type: 'message/append-delta',
+            type: 'message/attach-plan',
             id: assistantId,
-            text: event.text,
+            tasks: event.tasks,
+          });
+        } else if (event.type === 'task-start') {
+          dispatch({
+            type: 'message/task-status',
+            id: assistantId,
+            taskId: event.id,
+            status: 'running',
+          });
+        } else if (event.type === 'task-done') {
+          dispatch({
+            type: 'message/task-status',
+            id: assistantId,
+            taskId: event.id,
+            status: event.ok ? 'done' : 'failed',
           });
         } else if (event.type === 'error') {
           dispatch({

--- a/apps/desktop/src/renderer/client/daemon.ts
+++ b/apps/desktop/src/renderer/client/daemon.ts
@@ -1,5 +1,11 @@
+export type PlanTask = {
+  id: string;
+  title: string;
+  hint?: string;
+};
+
 export type AgentEvent =
-  | { type: 'text-delta'; text: string }
+  | { type: 'text-delta'; text: string; taskId?: string }
   | { type: 'tool-call'; id: string; name: string; args: unknown }
   | {
       type: 'tool-result';
@@ -8,6 +14,9 @@ export type AgentEvent =
       result?: unknown;
       error?: string;
     }
+  | { type: 'plan'; tasks: PlanTask[] }
+  | { type: 'task-start'; id: string }
+  | { type: 'task-done'; id: string; ok: boolean }
   | {
       type: 'done';
       sessionId?: string;
@@ -16,6 +25,14 @@ export type AgentEvent =
       billing?: 'subscription' | 'api';
     }
   | { type: 'error'; message: string };
+
+export type TaskRecord = {
+  id: string;
+  title: string;
+  hint?: string;
+  status: 'done' | 'failed';
+  result: string;
+};
 
 export type ProviderInfo = {
   id: string;
@@ -27,6 +44,7 @@ export type ProviderInfo = {
 export type SessionMessage = {
   role: 'user' | 'assistant' | 'system';
   content: string;
+  plan?: { tasks: TaskRecord[] };
 };
 
 export type SessionSummary = {

--- a/apps/desktop/src/renderer/components/Chat.tsx
+++ b/apps/desktop/src/renderer/components/Chat.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import type { ChatTurn } from '../state/useAtlas';
 import type { ProviderInfo } from '../client/daemon';
 import { Markdown } from './Markdown';
+import { TaskChecklist } from './TaskChecklist';
 
 type Props = {
   messages: ChatTurn[];
@@ -39,21 +40,29 @@ export function Chat({ messages, streaming, activeProvider }: Props) {
             </p>
           </div>
         ) : (
-          messages.map((m, i) => (
-            <div key={m.id} className={`msg ${m.role}`}>
-              <div className="role">{m.role === 'user' ? 'You' : 'Atlas'}</div>
-              <div className="content">
-                {m.role === 'assistant' ? (
-                  <Markdown>{m.content}</Markdown>
-                ) : (
-                  m.content
-                )}
-                {streaming && i === messages.length - 1 && m.role === 'assistant' && (
-                  <span className="caret" aria-hidden="true" />
-                )}
+          messages.map((m, i) => {
+            const isLast = i === messages.length - 1;
+            const showCaret =
+              streaming && isLast && m.role === 'assistant' && !m.plan;
+            return (
+              <div key={m.id} className={`msg ${m.role}`}>
+                <div className="role">{m.role === 'user' ? 'You' : 'Atlas'}</div>
+                <div className="content">
+                  {m.role === 'assistant' && m.plan ? (
+                    <TaskChecklist
+                      tasks={m.plan.tasks}
+                      streaming={streaming && isLast}
+                    />
+                  ) : m.role === 'assistant' ? (
+                    <Markdown>{m.content}</Markdown>
+                  ) : (
+                    m.content
+                  )}
+                  {showCaret && <span className="caret" aria-hidden="true" />}
+                </div>
               </div>
-            </div>
-          ))
+            );
+          })
         )}
       </div>
     </>

--- a/apps/desktop/src/renderer/components/TaskChecklist.tsx
+++ b/apps/desktop/src/renderer/components/TaskChecklist.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import type { TaskState } from '../state/useAtlas';
+import { Markdown } from './Markdown';
+
+type Props = {
+  tasks: TaskState[];
+  streaming: boolean;
+};
+
+export function TaskChecklist({ tasks, streaming }: Props) {
+  return (
+    <div className="task-checklist">
+      {tasks.map((task) => (
+        <TaskItem key={task.id} task={task} streaming={streaming} />
+      ))}
+    </div>
+  );
+}
+
+function TaskItem({ task, streaming }: { task: TaskState; streaming: boolean }) {
+  const [open, setOpen] = useState(task.status === 'running');
+  const showCaret =
+    streaming && task.status === 'running' && task.result.length > 0;
+
+  return (
+    <div className={`task-item status-${task.status}`}>
+      <button
+        type="button"
+        className="task-row"
+        onClick={() => setOpen((v) => !v)}
+        disabled={task.result.length === 0 && task.status !== 'running'}
+      >
+        <span className="task-status" aria-hidden="true">
+          {statusGlyph(task.status)}
+        </span>
+        <span className="task-title">{task.title}</span>
+        {task.result.length > 0 && (
+          <span className="task-toggle" aria-hidden="true">
+            {open ? '–' : '+'}
+          </span>
+        )}
+      </button>
+      {open && task.result.length > 0 && (
+        <div className="task-result">
+          <Markdown>{task.result}</Markdown>
+          {showCaret && <span className="caret" aria-hidden="true" />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function statusGlyph(status: TaskState['status']): string {
+  switch (status) {
+    case 'pending':
+      return '○';
+    case 'running':
+      return '◐';
+    case 'done':
+      return '●';
+    case 'failed':
+      return '✕';
+  }
+}

--- a/apps/desktop/src/renderer/state/useAtlas.ts
+++ b/apps/desktop/src/renderer/state/useAtlas.ts
@@ -1,12 +1,27 @@
 import { useEffect, useReducer } from 'react';
-import type { ProviderInfo, Session, SessionSummary } from '../client/daemon';
+import type {
+  PlanTask,
+  ProviderInfo,
+  Session,
+  SessionSummary,
+  TaskRecord,
+} from '../client/daemon';
 
 export type ThemePref = 'light' | 'dark' | 'system';
+
+export type TaskState = {
+  id: string;
+  title: string;
+  hint?: string;
+  status: 'pending' | 'running' | 'done' | 'failed';
+  result: string;
+};
 
 export type ChatTurn = {
   id: string;
   role: 'user' | 'assistant';
   content: string;
+  plan?: { tasks: TaskState[] };
 };
 
 export type AtlasState = {
@@ -33,8 +48,38 @@ type Action =
   | { type: 'message/start-assistant'; id: string }
   | { type: 'message/append-delta'; id: string; text: string }
   | { type: 'message/finish-assistant'; id: string }
+  | { type: 'message/attach-plan'; id: string; tasks: PlanTask[] }
+  | {
+      type: 'message/task-status';
+      id: string;
+      taskId: string;
+      status: TaskState['status'];
+    }
+  | { type: 'message/task-delta'; id: string; taskId: string; text: string }
   | { type: 'session/new' }
   | { type: 'daemon/reachable'; reachable: boolean };
+
+function recordToState(r: TaskRecord): TaskState {
+  const out: TaskState = {
+    id: r.id,
+    title: r.title,
+    status: r.status,
+    result: r.result,
+  };
+  if (r.hint) out.hint = r.hint;
+  return out;
+}
+
+function planTaskToState(t: PlanTask): TaskState {
+  const out: TaskState = {
+    id: t.id,
+    title: t.title,
+    status: 'pending',
+    result: '',
+  };
+  if (t.hint) out.hint = t.hint;
+  return out;
+}
 
 function reducer(state: AtlasState, action: Action): AtlasState {
   switch (action.type) {
@@ -62,10 +107,18 @@ function reducer(state: AtlasState, action: Action): AtlasState {
         currentSessionId: action.session.id,
         activeProviderId: action.session.providerId,
         messages: action.session.messages
-          .filter((m): m is { role: 'user' | 'assistant'; content: string } =>
-            m.role === 'user' || m.role === 'assistant',
-          )
-          .map((m) => ({ id: crypto.randomUUID(), ...m })),
+          .filter((m) => m.role === 'user' || m.role === 'assistant')
+          .map((m) => {
+            const turn: ChatTurn = {
+              id: crypto.randomUUID(),
+              role: m.role as 'user' | 'assistant',
+              content: m.content,
+            };
+            if (m.plan) {
+              turn.plan = { tasks: m.plan.tasks.map(recordToState) };
+            }
+            return turn;
+          }),
         streaming: false,
       };
     case 'settings/toggle':
@@ -99,6 +152,47 @@ function reducer(state: AtlasState, action: Action): AtlasState {
       };
     case 'message/finish-assistant':
       return { ...state, streaming: false };
+    case 'message/attach-plan':
+      return {
+        ...state,
+        messages: state.messages.map((m) =>
+          m.id === action.id
+            ? { ...m, plan: { tasks: action.tasks.map(planTaskToState) } }
+            : m,
+        ),
+      };
+    case 'message/task-status':
+      return {
+        ...state,
+        messages: state.messages.map((m) => {
+          if (m.id !== action.id || !m.plan) return m;
+          return {
+            ...m,
+            plan: {
+              tasks: m.plan.tasks.map((t) =>
+                t.id === action.taskId ? { ...t, status: action.status } : t,
+              ),
+            },
+          };
+        }),
+      };
+    case 'message/task-delta':
+      return {
+        ...state,
+        messages: state.messages.map((m) => {
+          if (m.id !== action.id || !m.plan) return m;
+          return {
+            ...m,
+            plan: {
+              tasks: m.plan.tasks.map((t) =>
+                t.id === action.taskId
+                  ? { ...t, result: t.result + action.text }
+                  : t,
+              ),
+            },
+          };
+        }),
+      };
     case 'session/new':
       return {
         ...state,

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -253,6 +253,70 @@ button { font: inherit; }
 .convo-item.active .convo-delete { opacity: 1; }
 .convo-delete:hover { background: var(--card-hover); color: var(--danger, #d93b3b); }
 
+/* ── task checklist ───────────────────────────────────────── */
+.task-checklist {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 4px 0;
+}
+
+.task-item {
+  border: 1px solid var(--border-faint, rgba(0, 0, 0, 0.08));
+  border-radius: 8px;
+  background: var(--card, transparent);
+  overflow: hidden;
+}
+
+.task-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  color: var(--text);
+}
+.task-row:disabled { cursor: default; }
+.task-row:hover:not(:disabled) { background: var(--card-hover); }
+
+.task-status {
+  flex: none;
+  width: 16px;
+  text-align: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--text-mute);
+}
+.status-running .task-status { color: var(--accent); }
+.status-done .task-status { color: #6aa84f; }
+.status-failed .task-status { color: var(--danger, #d93b3b); }
+
+.task-title {
+  flex: 1;
+  font-size: 13.5px;
+  color: var(--text);
+}
+.status-pending .task-title { color: var(--text-mute); }
+
+.task-toggle {
+  flex: none;
+  color: var(--text-faint);
+  font-size: 14px;
+  width: 16px;
+  text-align: center;
+}
+
+.task-result {
+  padding: 8px 14px 12px 38px;
+  border-top: 1px solid var(--border-faint, rgba(0, 0, 0, 0.06));
+  font-size: 13.5px;
+  line-height: 1.55;
+}
+
 .empty-hint {
   padding: 10px 14px;
   font-size: 12.5px;

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -116,6 +116,9 @@ flowchart TB
 当前已落地：
 - `title`（首轮 user+assistant 后异步生成会话标题）
 - `compaction`（每轮调 provider 前估字符数；超阈值时把"老消息"换成一条 `system` 总结，保留最近 K 条原文）
+- `plan` + `build`（每轮 chat 由 orchestrator 串接：plan 输出结构化 task list 或决定 `direct`；非 direct 时 build 按 task 顺序调 provider，把前面 task 的结果灌进后续 prompt）
+
+`/chat` 现在统一走 `agents/orchestrator.ts`，不再裸调 provider。direct 路径退化成"single shot"，对外行为与改造前一致；planned 路径额外发 `plan` / `task-start` / `task-done` 事件，`text-delta` 多带一个 `taskId` 字段。session 存储里 assistant 那条消息可以挂 `plan: { tasks: TaskRecord[] }`，UI 重新打开会话能恢复 task checklist。
 
 ## 关键决策
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -30,6 +30,7 @@ atlas/
 │   │       ├── http/           # HTTP 路由：/chat、/providers、/sessions、SSE 编码
 │   │       ├── agent/          # native agent loop（Vercel AI SDK），非 Claude 路径用
 │   │       │   └── loop.ts
+│   │       ├── agents/         # 多 agent 编排：plan / build / orchestrator，/chat 走这层
 │   │       ├── providers/      # provider 抽象 + 凭据存储 + 各家 adapter
 │   │       │   ├── types.ts
 │   │       │   ├── registry.ts


### PR DESCRIPTION
## Summary
落地多 agent 架构里两个真 agent：\`plan\` 把用户 query 拆成结构化 task list（或决定不需要拆），\`build\` 按顺序执行每个 task 并产出 SSE 事件。\`/chat\` 整体改走 \`orchestrator\`，不再裸调 provider；前端把 tasks 渲染成可折叠的 checklist，跑到哪步高亮哪步。

\`title\` / \`compaction\` 在 PR #19 / #21 已落地；本 PR 是多 agent 系列的最后一块。

## Changes（daemon）
- \`agents/plan.ts\` — runPlan 让模型出 JSON，解析失败 / role 未配置 / provider 失败一律 fallback 到 \`{kind:'direct'}\`
- \`agents/build.ts\` — 按 task 顺序调 provider，前 task 结果作为 assistant 消息塞进后续 prompt；任意 task 失败立即停下游
- \`agents/orchestrator.ts\` — plan → 看 kind 决定 build 多步路径或 direct 单流路径
- \`providers/types.ts\` — \`AgentEvent\` 加 \`plan\` / \`task-start\` / \`task-done\`；\`text-delta\` 加可选 \`taskId\`
- \`sessions/store.ts\` — \`SessionMessage\` 加可选 \`plan?: { tasks: TaskRecord[] }\`
- \`http/chat.ts\` — \`persistAssistant\` 改成 collector：direct buf + 按 taskId 分桶的 task buf，结束时拼 content + plan 写回 session

## Changes（desktop）
- \`client/daemon.ts\` — \`AgentEvent\` / \`SessionMessage\` 类型扩展
- \`state/useAtlas.ts\` — \`ChatTurn.plan?\` + 三个新 action：\`attach-plan\` / \`task-status\` / \`task-delta\`；\`session/load\` 还原 \`TaskRecord\` 到 \`TaskState\`
- \`components/TaskChecklist.tsx\` — 状态点 (○◐●✕) + 折叠 result panel，running 自动展开
- \`components/Chat.tsx\` — 有 plan 走 TaskChecklist，否则现有 markdown
- \`App.tsx\` — 按 SSE 事件类型 dispatch；\`text-delta.taskId\` 路由到 task-delta

## Test plan
- [x] \`bun test\`（daemon 109 / desktop 14 全绿）
- [x] \`bun run check\`（两侧 tsc 干净）
- [x] daemon smoke：启动 + \`/health\` + \`/sessions\` 正常
- [ ] 端到端：\`config.json\` 加 \`roles.plan\` 指向能输出 JSON 的模型 → 启 daemon + electron → 发个复杂 query → 看到 task checklist 实时打勾；重启后会话能恢复 plan
- [ ] 简单 query（如 "hi"）走 direct 路径，仍然单流文本

## Caveats
**build 现在没工具可调**——RAG / web search 都还没接，所以 "plan 出 N 步、build 一步一步答"今天约等于"先列大纲再填"。等工具接进来后真正价值才解锁；SSE 协议、storage 形状、UI 渲染管线本 PR 已就位，后续不用再改一遍。

## Related
Closes #22