### PR TITLE
feat(desktop): distinguish chat messages with right-aligned user bubble

### DIFF
--- a/apps/desktop/src/renderer/components/Chat.tsx
+++ b/apps/desktop/src/renderer/components/Chat.tsx
@@ -46,7 +46,6 @@ export function Chat({ messages, streaming, activeProvider }: Props) {
               streaming && isLast && m.role === 'assistant' && !m.plan;
             return (
               <div key={m.id} className={`msg ${m.role}`}>
-                <div className="role">{m.role === 'user' ? 'You' : 'Atlas'}</div>
                 <div className="content">
                   {m.role === 'assistant' && m.plan ? (
                     <TaskChecklist

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -439,33 +439,34 @@ button { font: inherit; }
 
 .msg {
   max-width: 720px;
-  margin: 0 auto 28px;
+  margin: 0 auto 22px;
   padding: 0 32px;
-}
-.msg .role {
-  font-size: 12px;
-  color: var(--text-mute);
-  margin-bottom: 8px;
-  font-weight: 500;
   display: flex;
-  align-items: center;
-  gap: 8px;
 }
-.msg.assistant .role::before {
-  content: '';
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent);
-}
+.msg.assistant { justify-content: flex-start; }
+.msg.user { justify-content: flex-end; }
+
 .msg .content {
   font-size: 14.5px;
   line-height: 1.72;
   color: var(--text);
 }
-/* user messages are plain text — preserve typed line breaks */
+
+/* assistant: flowing text, full reading width */
+.msg.assistant .content {
+  flex: 1;
+  min-width: 0;
+}
+
+/* user: right-aligned rounded bubble with subtle tint */
 .msg.user .content {
   white-space: pre-wrap;
+  max-width: 80%;
+  padding: 10px 14px;
+  background: var(--accent-soft);
+  border-radius: 14px 14px 4px 14px;
+  font-size: 14px;
+  line-height: 1.6;
 }
 
 /* inline code (also applies to <code> inside <pre>, overridden below) */


### PR DESCRIPTION
## Summary
当前对话界面中用户和 Agent 消息样式几乎一致，靠小标签区分不直观。本 PR 把用户消息改成右对齐淡色气泡，Agent 消息保持左侧通栏 markdown，移除冗余的 "You" / "Atlas" 标签。

## Changes
- `apps/desktop/src/renderer/components/Chat.tsx`: 移除消息顶部 role 标签
- `apps/desktop/src/renderer/styles.css`:
  - `.msg` 改为 flex 容器，`user` 右对齐、`assistant` 左对齐铺满
  - `.msg.user .content`: `accent-soft` 底色 + 14px 圆角（右下 4px）+ 80% 最大宽
  - `.msg.assistant .content`: `flex: 1` 保留 markdown 通栏阅读宽度

## Test plan
- [ ] `bun --cwd apps/desktop run check` 通过
- [ ] 启动 `bun --cwd apps/desktop dev`，在对话中发送 user 消息和接收 assistant 回复
- [ ] User 气泡右对齐、有淡橙底；assistant 文本左对齐、通栏
- [ ] 浅色 / 深色主题下颜色都协调
- [ ] 长 markdown 回复（代码块、列表、表格）排版不被压缩

## Related
Closes #24